### PR TITLE
Move Supabase deletion to service layer and ensure DB cleanup in user delete

### DIFF
--- a/backend/src/routes/user.routes.ts
+++ b/backend/src/routes/user.routes.ts
@@ -9,7 +9,7 @@ import { authenticateToken } from '../middleware/auth';
 
 const router = Router();
 
-// POST User Sign Up
+// POST User signs up
 router.post('/user/signup', async (req: Request, res: Response) => {
   const { name, email, password } = req.body;
 
@@ -55,7 +55,7 @@ router.post('/user/signup', async (req: Request, res: Response) => {
   return responseHandler(res, result, 'POST');
 });
 
-// POST User Sign In
+// POST User signs in
 router.post('/user/signin', async (req: Request, res: Response) => {
   const { email, password } = req.body;
 
@@ -98,7 +98,7 @@ router.post('/user/signin', async (req: Request, res: Response) => {
   return responseHandler(res, result, 'POST');
 });
 
-// POST user sign out
+// POST User signs out
 router.post('/user/signout', async (_req: Request, res: Response) => {
   const signOutResult = await SupabaseProvider.signOut();
 
@@ -116,7 +116,7 @@ router.post('/user/signout', async (_req: Request, res: Response) => {
   return responseHandler(res, result, 'POST');
 });
 
-// POST user change password
+// POST User changes password
 router.post('/user/change-password', authenticateToken, async (req: Request, res: Response) => {
   const { newPassword } = req.body;
   const userId = req.user?.sub;
@@ -155,7 +155,7 @@ router.post('/user/change-password', authenticateToken, async (req: Request, res
   return responseHandler(res, result, 'POST');
 });
 
-// POST user password reset
+// POST User resets password
 router.post('/user/send-magic-link', async (req: Request, res: Response) => {
   const { email } = req.body;
 
@@ -180,7 +180,7 @@ router.post('/user/send-magic-link', async (req: Request, res: Response) => {
   return responseHandler(res, result, 'POST');
 });
 
-// POST refresh session token
+// POST User refreshes session token
 router.post('/user/refresh-token', async (req: Request, res: Response) => {
   const refreshToken = req.headers.authorization?.split(' ')[1]; // Bearer <refresh_token>
 
@@ -218,7 +218,7 @@ router.post('/user/refresh-token', async (req: Request, res: Response) => {
   return responseHandler(res, result, 'POST');
 });
 
-// DELETE user account
+// DELETE User deletes account
 router.delete('/user/delete-account', authenticateToken, async (req: Request, res: Response) => {
   const userId = typeof req.user?.sub === 'string' ? req.user.sub : undefined; //`sub` is the Supabase user ID from the JWT token
 
@@ -230,18 +230,11 @@ router.delete('/user/delete-account', authenticateToken, async (req: Request, re
     );
   }
 
-  const deleteResult = await SupabaseProvider.deleteUserProfile(userId);
+  const result = await UserService.userDeleteAccount(userId);
 
-  if (!deleteResult.success) {
-    return responseHandler(res, { success: false, error: deleteResult.error }, 'DELETE');
+  if (!result.success) {
+    return responseHandler(res, { success: false, error: result.error }, 'DELETE');
   }
-
-  const result = {
-    success: true,
-    data: {
-      message: 'User profile deleted successfully.',
-    },
-  };
 
   return responseHandler(res, result, 'DELETE');
 });

--- a/backend/src/services/user.service.ts
+++ b/backend/src/services/user.service.ts
@@ -1,15 +1,20 @@
 import { prisma } from '../db/prisma';
 
 import { handlePrismaRequestError } from '../utils/errorHandler';
-import { validateUserInput } from '../utils/inputValidation';
+import { validateUserInput, validateId } from '../utils/inputValidation';
 import { logger } from '../utils/logger';
 
 import { User, ServiceResponse } from '../types/types';
+import { SupabaseProvider } from '../providers/supabase.provider';
 
 export const UserService = {
   async userCreateUser(id: string, name: string, email: string): Promise<ServiceResponse<User>> {
     const validationResult = validateUserInput(name, email);
+
     if (!validationResult.success) {
+      logger.error(
+        '[UserService] Validation failed during user creation - check email and username.',
+      );
       return {
         success: false,
         error: validationResult.error ?? '',
@@ -21,14 +26,41 @@ export const UserService = {
         data: { id, name, email, role: 'USER' },
       });
 
-      await logger.success(`[UserService] User created successfully:`, user.email);
-
+      logger.success(`[UserService] User created successfully:`, user.email);
       return { success: true, data: user as User };
     } catch (error) {
       return handlePrismaRequestError(error, 'creating user', 'UserService');
     }
   },
 
-  //TODO:
-  // await prisma.user.delete({ where: { id: userId } });
+  async userDeleteAccount(userId: string): Promise<ServiceResponse<null>> {
+    const idValidation = validateId(userId);
+
+    if (!idValidation.success) {
+      logger.error(
+        `[UserService] Failed to delete account - ID validation error:: ${idValidation.error}`,
+      );
+      return { success: false, error: idValidation.error ?? '' };
+    }
+
+    try {
+      // 1. Delete Supabase Auth user:
+      const result = await SupabaseProvider.deleteUserProfile(userId);
+
+      if (!result.success) {
+        logger.error(
+          `[UserService] Failed to delete Supabase user | ID: ${userId} | Error: ${result.error}`,
+        );
+        return { success: false, error: `Failed to delete auth user: ${result.error}` };
+      }
+
+      // 2. delete from db
+      await prisma.user.delete({ where: { id: userId } });
+
+      logger.success(`[UserService] Account deleted successfully ${userId}`);
+      return { success: true, data: null };
+    } catch (error) {
+      return handlePrismaRequestError(error, 'deleting user', 'UserService');
+    }
+  },
 };


### PR DESCRIPTION
This PR refactors the /user/delete-account route by moving the Supabase deletion call into the UserService and ensuring proper DB cleanup logic. This aligns the user deletion flow with the admin flow for consistency, improves separation of concerns, and avoids redundant external calls.