### PR TITLE
feat: add REDOC API documentation endpoint

### DIFF
--- a/backend/openapi/index.html
+++ b/backend/openapi/index.html
@@ -1,0 +1,3633 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf8" />
+    <title>Admin API</title>
+    <!-- needed for adaptive design -->
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      body {
+        padding: 0;
+        margin: 0;
+      }
+    </style>
+    <script src="https://cdn.redocly.com/redoc/v2.5.0/bundles/redoc.standalone.js"></script>
+    <style data-styled="true" data-styled-version="6.1.19">
+      .fqkwbU {
+        width: calc(100% - 40%);
+        padding: 0 40px;
+      } /*!sc*/
+      @media print, screen and (max-width: 75rem) {
+        .fqkwbU {
+          width: 100%;
+          padding: 40px 40px;
+        }
+      } /*!sc*/
+      .dCzIPc {
+        width: calc(100% - 40%);
+        padding: 0 40px;
+      } /*!sc*/
+      @media print, screen and (max-width: 75rem) {
+        .dCzIPc {
+          width: 100%;
+          padding: 0px 40px;
+        }
+      } /*!sc*/
+      data-styled.g4[id='sc-ggWZvA'] {
+        content: 'fqkwbU,dCzIPc,';
+      } /*!sc*/
+      .bPmFpz {
+        padding: 40px 0;
+      } /*!sc*/
+      .bPmFpz:last-child {
+        min-height: calc(100vh + 1px);
+      } /*!sc*/
+      .bPmFpz > .bPmFpz:last-child {
+        min-height: initial;
+      } /*!sc*/
+      @media print, screen and (max-width: 75rem) {
+        .bPmFpz {
+          padding: 0;
+        }
+      } /*!sc*/
+      .gHrCVQ {
+        padding: 40px 0;
+        position: relative;
+      } /*!sc*/
+      .gHrCVQ:last-child {
+        min-height: calc(100vh + 1px);
+      } /*!sc*/
+      .gHrCVQ > .gHrCVQ:last-child {
+        min-height: initial;
+      } /*!sc*/
+      @media print, screen and (max-width: 75rem) {
+        .gHrCVQ {
+          padding: 0;
+        }
+      } /*!sc*/
+      .gHrCVQ:not(:last-of-type):after {
+        position: absolute;
+        bottom: 0;
+        width: 100%;
+        display: block;
+        content: '';
+        border-bottom: 1px solid rgba(0, 0, 0, 0.2);
+      } /*!sc*/
+      data-styled.g5[id='sc-dTvVRJ'] {
+        content: 'bPmFpz,gHrCVQ,';
+      } /*!sc*/
+      .bDYKKx {
+        width: 40%;
+        color: #ffffff;
+        background-color: #263238;
+        padding: 0 40px;
+      } /*!sc*/
+      @media print, screen and (max-width: 75rem) {
+        .bDYKKx {
+          width: 100%;
+          padding: 40px 40px;
+        }
+      } /*!sc*/
+      data-styled.g6[id='sc-jwTyAe'] {
+        content: 'bDYKKx,';
+      } /*!sc*/
+      .FFPsr {
+        background-color: #263238;
+      } /*!sc*/
+      data-styled.g7[id='sc-hjsuWn'] {
+        content: 'FFPsr,';
+      } /*!sc*/
+      .gkiSyE {
+        display: flex;
+        width: 100%;
+        padding: 0;
+      } /*!sc*/
+      @media print, screen and (max-width: 75rem) {
+        .gkiSyE {
+          flex-direction: column;
+        }
+      } /*!sc*/
+      data-styled.g8[id='sc-jJLAfE'] {
+        content: 'gkiSyE,';
+      } /*!sc*/
+      .wYHiz {
+        font-family: Montserrat, sans-serif;
+        font-weight: 400;
+        font-size: 1.85714em;
+        line-height: 1.6em;
+        color: #333333;
+      } /*!sc*/
+      data-styled.g9[id='sc-hwkwBN'] {
+        content: 'wYHiz,';
+      } /*!sc*/
+      .iFSqkw {
+        font-family: Montserrat, sans-serif;
+        font-weight: 400;
+        font-size: 1.57143em;
+        line-height: 1.6em;
+        color: #333333;
+        margin: 0 0 20px;
+      } /*!sc*/
+      data-styled.g10[id='sc-kNOymR'] {
+        content: 'iFSqkw,';
+      } /*!sc*/
+      .drJHMo {
+        color: #ffffff;
+      } /*!sc*/
+      data-styled.g12[id='sc-lgpSej'] {
+        content: 'drJHMo,';
+      } /*!sc*/
+      .czjApA {
+        border-bottom: 1px solid rgba(38, 50, 56, 0.3);
+        margin: 1em 0 1em 0;
+        color: rgba(38, 50, 56, 0.5);
+        font-weight: normal;
+        text-transform: uppercase;
+        font-size: 0.929em;
+        line-height: 20px;
+      } /*!sc*/
+      data-styled.g13[id='sc-eqYatC'] {
+        content: 'czjApA,';
+      } /*!sc*/
+      .fRdsOi {
+        cursor: pointer;
+        margin-left: -20px;
+        padding: 0;
+        line-height: 1;
+        width: 20px;
+        display: inline-block;
+        outline: 0;
+      } /*!sc*/
+      .fRdsOi:before {
+        content: '';
+        width: 15px;
+        height: 15px;
+        background-size: contain;
+        background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZlcnNpb249IjEuMSIgeD0iMCIgeT0iMCIgd2lkdGg9IjUxMiIgaGVpZ2h0PSI1MTIiIHZpZXdCb3g9IjAgMCA1MTIgNTEyIiBlbmFibGUtYmFja2dyb3VuZD0ibmV3IDAgMCA1MTIgNTEyIiB4bWw6c3BhY2U9InByZXNlcnZlIj48cGF0aCBmaWxsPSIjMDEwMTAxIiBkPSJNNDU5LjcgMjMzLjRsLTkwLjUgOTAuNWMtNTAgNTAtMTMxIDUwLTE4MSAwIC03LjktNy44LTE0LTE2LjctMTkuNC0yNS44bDQyLjEtNDIuMWMyLTIgNC41LTMuMiA2LjgtNC41IDIuOSA5LjkgOCAxOS4zIDE1LjggMjcuMiAyNSAyNSA2NS42IDI0LjkgOTAuNSAwbDkwLjUtOTAuNWMyNS0yNSAyNS02NS42IDAtOTAuNSAtMjQuOS0yNS02NS41LTI1LTkwLjUgMGwtMzIuMiAzMi4yYy0yNi4xLTEwLjItNTQuMi0xMi45LTgxLjYtOC45bDY4LjYtNjguNmM1MC01MCAxMzEtNTAgMTgxIDBDNTA5LjYgMTAyLjMgNTA5LjYgMTgzLjQgNDU5LjcgMjMzLjR6TTIyMC4zIDM4Mi4ybC0zMi4yIDMyLjJjLTI1IDI0LjktNjUuNiAyNC45LTkwLjUgMCAtMjUtMjUtMjUtNjUuNiAwLTkwLjVsOTAuNS05MC41YzI1LTI1IDY1LjUtMjUgOTAuNSAwIDcuOCA3LjggMTIuOSAxNy4yIDE1LjggMjcuMSAyLjQtMS40IDQuOC0yLjUgNi44LTQuNWw0Mi4xLTQyYy01LjQtOS4yLTExLjYtMTgtMTkuNC0yNS44IC01MC01MC0xMzEtNTAtMTgxIDBsLTkwLjUgOTAuNWMtNTAgNTAtNTAgMTMxIDAgMTgxIDUwIDUwIDEzMSA1MCAxODEgMGw2OC42LTY4LjZDMjc0LjYgMzk1LjEgMjQ2LjQgMzkyLjMgMjIwLjMgMzgyLjJ6Ii8+PC9zdmc+Cg==');
+        opacity: 0.5;
+        visibility: hidden;
+        display: inline-block;
+        vertical-align: middle;
+      } /*!sc*/
+      h1:hover > .fRdsOi::before,
+      h2:hover > .fRdsOi::before,
+      .fRdsOi:hover::before {
+        visibility: visible;
+      } /*!sc*/
+      data-styled.g14[id='sc-kcLKEh'] {
+        content: 'fRdsOi,';
+      } /*!sc*/
+      .dUlzCe {
+        height: 18px;
+        width: 18px;
+        min-width: 18px;
+        vertical-align: middle;
+        float: right;
+        transition: transform 0.2s ease-out;
+        transform: rotateZ(-90deg);
+      } /*!sc*/
+      .FtowP {
+        height: 1.3em;
+        width: 1.3em;
+        min-width: 1.3em;
+        vertical-align: middle;
+        transition: transform 0.2s ease-out;
+        transform: rotateZ(-90deg);
+      } /*!sc*/
+      .cGxVlA {
+        height: 1.5em;
+        width: 1.5em;
+        min-width: 1.5em;
+        vertical-align: middle;
+        float: left;
+        transition: transform 0.2s ease-out;
+        transform: rotateZ(-90deg);
+      } /*!sc*/
+      .cGxVlA polygon {
+        fill: #1d8127;
+      } /*!sc*/
+      .jKYZgc {
+        height: 1.5em;
+        width: 1.5em;
+        min-width: 1.5em;
+        vertical-align: middle;
+        float: left;
+        transition: transform 0.2s ease-out;
+        transform: rotateZ(-90deg);
+      } /*!sc*/
+      .jKYZgc polygon {
+        fill: #d41f1c;
+      } /*!sc*/
+      .iuNpUs {
+        height: 20px;
+        width: 20px;
+        min-width: 20px;
+        vertical-align: middle;
+        float: right;
+        transition: transform 0.2s ease-out;
+        transform: rotateZ(0);
+      } /*!sc*/
+      .iuNpUs polygon {
+        fill: white;
+      } /*!sc*/
+      data-styled.g15[id='sc-dntSTA'] {
+        content: 'dUlzCe,FtowP,cGxVlA,jKYZgc,iuNpUs,';
+      } /*!sc*/
+      .gdmNWp {
+        border-left: 1px solid #7c7cbb;
+        box-sizing: border-box;
+        position: relative;
+        padding: 10px 10px 10px 0;
+      } /*!sc*/
+      @media screen and (max-width: 50rem) {
+        .gdmNWp {
+          display: block;
+          overflow: hidden;
+        }
+      } /*!sc*/
+      tr:first-of-type > .gdmNWp,
+      tr.last > .gdmNWp {
+        border-left-width: 0;
+        background-position: top left;
+        background-repeat: no-repeat;
+        background-size: 1px 100%;
+      } /*!sc*/
+      tr:first-of-type > .gdmNWp {
+        background-image: linear-gradient(
+          to bottom,
+          transparent 0%,
+          transparent 22px,
+          #7c7cbb 22px,
+          #7c7cbb 100%
+        );
+      } /*!sc*/
+      tr.last > .gdmNWp {
+        background-image: linear-gradient(
+          to bottom,
+          #7c7cbb 0%,
+          #7c7cbb 22px,
+          transparent 22px,
+          transparent 100%
+        );
+      } /*!sc*/
+      tr.last + tr > .gdmNWp {
+        border-left-color: transparent;
+      } /*!sc*/
+      tr.last:first-child > .gdmNWp {
+        background: none;
+        border-left-color: transparent;
+      } /*!sc*/
+      data-styled.g18[id='sc-kCuUfV'] {
+        content: 'gdmNWp,';
+      } /*!sc*/
+      .dFOJWJ {
+        vertical-align: top;
+        line-height: 20px;
+        white-space: nowrap;
+        font-size: 13px;
+        font-family: Courier, monospace;
+      } /*!sc*/
+      .dFOJWJ.deprecated {
+        text-decoration: line-through;
+        color: #707070;
+      } /*!sc*/
+      data-styled.g20[id='sc-fbQrwq'] {
+        content: 'dFOJWJ,';
+      } /*!sc*/
+      .ixGaBD {
+        border-bottom: 1px solid #9fb4be;
+        padding: 10px 0;
+        width: 75%;
+        box-sizing: border-box;
+      } /*!sc*/
+      tr.expanded .ixGaBD {
+        border-bottom: none;
+      } /*!sc*/
+      @media screen and (max-width: 50rem) {
+        .ixGaBD {
+          padding: 0 20px;
+          border-bottom: none;
+          border-left: 1px solid #7c7cbb;
+        }
+        tr.last > .ixGaBD {
+          border-left: none;
+        }
+      } /*!sc*/
+      data-styled.g21[id='sc-gGKoUb'] {
+        content: 'ixGaBD,';
+      } /*!sc*/
+      .cteAyA {
+        color: #7c7cbb;
+        font-family: Courier, monospace;
+        margin-right: 10px;
+      } /*!sc*/
+      .cteAyA::before {
+        content: '';
+        display: inline-block;
+        vertical-align: middle;
+        width: 10px;
+        height: 1px;
+        background: #7c7cbb;
+      } /*!sc*/
+      .cteAyA::after {
+        content: '';
+        display: inline-block;
+        vertical-align: middle;
+        width: 1px;
+        background: #7c7cbb;
+        height: 7px;
+      } /*!sc*/
+      data-styled.g22[id='sc-hwddKA'] {
+        content: 'cteAyA,';
+      } /*!sc*/
+      .icJLQx {
+        border-collapse: separate;
+        border-radius: 3px;
+        font-size: 14px;
+        border-spacing: 0;
+        width: 100%;
+      } /*!sc*/
+      .icJLQx > tr {
+        vertical-align: middle;
+      } /*!sc*/
+      @media screen and (max-width: 50rem) {
+        .icJLQx {
+          display: block;
+        }
+        .icJLQx > tr,
+        .icJLQx > tbody > tr {
+          display: block;
+        }
+      } /*!sc*/
+      @media screen and (max-width: 50rem) and (-ms-high-contrast: none) {
+        .icJLQx td {
+          float: left;
+          width: 100%;
+        }
+      } /*!sc*/
+      .icJLQx .sc-jaXbil,
+      .icJLQx .sc-jaXbil .sc-jaXbil .sc-jaXbil,
+      .icJLQx .sc-jaXbil .sc-jaXbil .sc-jaXbil .sc-jaXbil .sc-jaXbil {
+        margin: 1em;
+        margin-right: 0;
+        background: #fafafa;
+      } /*!sc*/
+      .icJLQx .sc-jaXbil .sc-jaXbil,
+      .icJLQx .sc-jaXbil .sc-jaXbil .sc-jaXbil .sc-jaXbil,
+      .icJLQx .sc-jaXbil .sc-jaXbil .sc-jaXbil .sc-jaXbil .sc-jaXbil .sc-jaXbil {
+        background: #ffffff;
+      } /*!sc*/
+      data-styled.g24[id='sc-eqNDNG'] {
+        content: 'icJLQx,';
+      } /*!sc*/
+      .fyxuKi > ul {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        margin: 0 -5px;
+      } /*!sc*/
+      .fyxuKi > ul > li {
+        padding: 5px 10px;
+        display: inline-block;
+        background-color: #11171a;
+        border-bottom: 1px solid rgba(0, 0, 0, 0.5);
+        cursor: pointer;
+        text-align: center;
+        outline: none;
+        color: #ccc;
+        margin: 0 5px 5px 5px;
+        border: 1px solid #07090b;
+        border-radius: 5px;
+        min-width: 60px;
+        font-size: 0.9em;
+        font-weight: bold;
+      } /*!sc*/
+      .fyxuKi > ul > li.react-tabs__tab--selected {
+        color: #333333;
+        background: #ffffff;
+      } /*!sc*/
+      .fyxuKi > ul > li.react-tabs__tab--selected:focus {
+        outline: auto;
+      } /*!sc*/
+      .fyxuKi > ul > li:only-child {
+        flex: none;
+        min-width: 100px;
+      } /*!sc*/
+      .fyxuKi > ul > li.tab-success {
+        color: #1d8127;
+      } /*!sc*/
+      .fyxuKi > ul > li.tab-redirect {
+        color: #ffa500;
+      } /*!sc*/
+      .fyxuKi > ul > li.tab-info {
+        color: #87ceeb;
+      } /*!sc*/
+      .fyxuKi > ul > li.tab-error {
+        color: #d41f1c;
+      } /*!sc*/
+      .fyxuKi > .react-tabs__tab-panel {
+        background: #11171a;
+      } /*!sc*/
+      .fyxuKi > .react-tabs__tab-panel > div,
+      .fyxuKi > .react-tabs__tab-panel > pre {
+        padding: 20px;
+        margin: 0;
+      } /*!sc*/
+      .fyxuKi > .react-tabs__tab-panel > div > pre {
+        padding: 0;
+      } /*!sc*/
+      data-styled.g30[id='sc-cOpnSz'] {
+        content: 'fyxuKi,';
+      } /*!sc*/
+      .kIppRw code[class*='language-'],
+      .kIppRw pre[class*='language-'] {
+        text-shadow: 0 -0.1em 0.2em black;
+        text-align: left;
+        white-space: pre;
+        word-spacing: normal;
+        word-break: normal;
+        word-wrap: normal;
+        line-height: 1.5;
+        -moz-tab-size: 4;
+        -o-tab-size: 4;
+        tab-size: 4;
+        -webkit-hyphens: none;
+        -moz-hyphens: none;
+        -ms-hyphens: none;
+        hyphens: none;
+      } /*!sc*/
+      @media print {
+        .kIppRw code[class*='language-'],
+        .kIppRw pre[class*='language-'] {
+          text-shadow: none;
+        }
+      } /*!sc*/
+      .kIppRw pre[class*='language-'] {
+        padding: 1em;
+        margin: 0.5em 0;
+        overflow: auto;
+      } /*!sc*/
+      .kIppRw .token.comment,
+      .kIppRw .token.prolog,
+      .kIppRw .token.doctype,
+      .kIppRw .token.cdata {
+        color: hsl(30, 20%, 50%);
+      } /*!sc*/
+      .kIppRw .token.punctuation {
+        opacity: 0.7;
+      } /*!sc*/
+      .kIppRw .namespace {
+        opacity: 0.7;
+      } /*!sc*/
+      .kIppRw .token.property,
+      .kIppRw .token.tag,
+      .kIppRw .token.number,
+      .kIppRw .token.constant,
+      .kIppRw .token.symbol {
+        color: #4a8bb3;
+      } /*!sc*/
+      .kIppRw .token.boolean {
+        color: #e64441;
+      } /*!sc*/
+      .kIppRw .token.selector,
+      .kIppRw .token.attr-name,
+      .kIppRw .token.string,
+      .kIppRw .token.char,
+      .kIppRw .token.builtin,
+      .kIppRw .token.inserted {
+        color: #a0fbaa;
+      } /*!sc*/
+      .kIppRw .token.selector + a,
+      .kIppRw .token.attr-name + a,
+      .kIppRw .token.string + a,
+      .kIppRw .token.char + a,
+      .kIppRw .token.builtin + a,
+      .kIppRw .token.inserted + a,
+      .kIppRw .token.selector + a:visited,
+      .kIppRw .token.attr-name + a:visited,
+      .kIppRw .token.string + a:visited,
+      .kIppRw .token.char + a:visited,
+      .kIppRw .token.builtin + a:visited,
+      .kIppRw .token.inserted + a:visited {
+        color: #4ed2ba;
+        text-decoration: underline;
+      } /*!sc*/
+      .kIppRw .token.property.string {
+        color: white;
+      } /*!sc*/
+      .kIppRw .token.operator,
+      .kIppRw .token.entity,
+      .kIppRw .token.url,
+      .kIppRw .token.variable {
+        color: hsl(40, 90%, 60%);
+      } /*!sc*/
+      .kIppRw .token.atrule,
+      .kIppRw .token.attr-value,
+      .kIppRw .token.keyword {
+        color: hsl(350, 40%, 70%);
+      } /*!sc*/
+      .kIppRw .token.regex,
+      .kIppRw .token.important {
+        color: #e90;
+      } /*!sc*/
+      .kIppRw .token.important,
+      .kIppRw .token.bold {
+        font-weight: bold;
+      } /*!sc*/
+      .kIppRw .token.italic {
+        font-style: italic;
+      } /*!sc*/
+      .kIppRw .token.entity {
+        cursor: help;
+      } /*!sc*/
+      .kIppRw .token.deleted {
+        color: red;
+      } /*!sc*/
+      data-styled.g32[id='sc-eVqvcJ'] {
+        content: 'kIppRw,';
+      } /*!sc*/
+      .bBWkcI {
+        opacity: 0.7;
+        transition: opacity 0.3s ease;
+        text-align: right;
+      } /*!sc*/
+      .bBWkcI:focus-within {
+        opacity: 1;
+      } /*!sc*/
+      .bBWkcI > button {
+        background-color: transparent;
+        border: 0;
+        color: inherit;
+        padding: 2px 10px;
+        font-family: Roboto, sans-serif;
+        font-size: 14px;
+        line-height: 1.5em;
+        cursor: pointer;
+        outline: 0;
+      } /*!sc*/
+      .bBWkcI > button :hover,
+      .bBWkcI > button :focus {
+        background: rgba(255, 255, 255, 0.1);
+      } /*!sc*/
+      data-styled.g33[id='sc-bbbBoY'] {
+        content: 'bBWkcI,';
+      } /*!sc*/
+      .ghzOpX {
+        position: relative;
+      } /*!sc*/
+      data-styled.g37[id='sc-eknHtZ'] {
+        content: 'ghzOpX,';
+      } /*!sc*/
+      .cFlAeY {
+        margin-left: 10px;
+        text-transform: none;
+        font-size: 0.929em;
+        color: black;
+      } /*!sc*/
+      data-styled.g41[id='sc-dNFkOE'] {
+        content: 'cFlAeY,';
+      } /*!sc*/
+      .kbZred {
+        font-family: Roboto, sans-serif;
+        font-weight: 400;
+        line-height: 1.5em;
+      } /*!sc*/
+      .kbZred p:last-child {
+        margin-bottom: 0;
+      } /*!sc*/
+      .kbZred h1 {
+        font-family: Montserrat, sans-serif;
+        font-weight: 400;
+        font-size: 1.85714em;
+        line-height: 1.6em;
+        color: #32329f;
+        margin-top: 0;
+      } /*!sc*/
+      .kbZred h2 {
+        font-family: Montserrat, sans-serif;
+        font-weight: 400;
+        font-size: 1.57143em;
+        line-height: 1.6em;
+        color: #333333;
+      } /*!sc*/
+      .kbZred code {
+        color: #e53935;
+        background-color: rgba(38, 50, 56, 0.05);
+        font-family: Courier, monospace;
+        border-radius: 2px;
+        border: 1px solid rgba(38, 50, 56, 0.1);
+        padding: 0 5px;
+        font-size: 13px;
+        font-weight: 400;
+        word-break: break-word;
+      } /*!sc*/
+      .kbZred pre {
+        font-family: Courier, monospace;
+        white-space: pre;
+        background-color: #11171a;
+        color: white;
+        padding: 20px;
+        overflow-x: auto;
+        line-height: normal;
+        border-radius: 0;
+        border: 1px solid rgba(38, 50, 56, 0.1);
+      } /*!sc*/
+      .kbZred pre code {
+        background-color: transparent;
+        color: white;
+        padding: 0;
+      } /*!sc*/
+      .kbZred pre code:before,
+      .kbZred pre code:after {
+        content: none;
+      } /*!sc*/
+      .kbZred blockquote {
+        margin: 0;
+        margin-bottom: 1em;
+        padding: 0 15px;
+        color: #777;
+        border-left: 4px solid #ddd;
+      } /*!sc*/
+      .kbZred img {
+        max-width: 100%;
+        box-sizing: content-box;
+      } /*!sc*/
+      .kbZred ul,
+      .kbZred ol {
+        padding-left: 2em;
+        margin: 0;
+        margin-bottom: 1em;
+      } /*!sc*/
+      .kbZred ul ul,
+      .kbZred ol ul,
+      .kbZred ul ol,
+      .kbZred ol ol {
+        margin-bottom: 0;
+        margin-top: 0;
+      } /*!sc*/
+      .kbZred table {
+        display: block;
+        width: 100%;
+        overflow: auto;
+        word-break: normal;
+        word-break: keep-all;
+        border-collapse: collapse;
+        border-spacing: 0;
+        margin-top: 1.5em;
+        margin-bottom: 1.5em;
+      } /*!sc*/
+      .kbZred table tr {
+        background-color: #fff;
+        border-top: 1px solid #ccc;
+      } /*!sc*/
+      .kbZred table tr:nth-child(2n) {
+        background-color: #fafafa;
+      } /*!sc*/
+      .kbZred table th,
+      .kbZred table td {
+        padding: 6px 13px;
+        border: 1px solid #ddd;
+      } /*!sc*/
+      .kbZred table th {
+        text-align: left;
+        font-weight: bold;
+      } /*!sc*/
+      .kbZred .share-link {
+        cursor: pointer;
+        margin-left: -20px;
+        padding: 0;
+        line-height: 1;
+        width: 20px;
+        display: inline-block;
+        outline: 0;
+      } /*!sc*/
+      .kbZred .share-link:before {
+        content: '';
+        width: 15px;
+        height: 15px;
+        background-size: contain;
+        background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZlcnNpb249IjEuMSIgeD0iMCIgeT0iMCIgd2lkdGg9IjUxMiIgaGVpZ2h0PSI1MTIiIHZpZXdCb3g9IjAgMCA1MTIgNTEyIiBlbmFibGUtYmFja2dyb3VuZD0ibmV3IDAgMCA1MTIgNTEyIiB4bWw6c3BhY2U9InByZXNlcnZlIj48cGF0aCBmaWxsPSIjMDEwMTAxIiBkPSJNNDU5LjcgMjMzLjRsLTkwLjUgOTAuNWMtNTAgNTAtMTMxIDUwLTE4MSAwIC03LjktNy44LTE0LTE2LjctMTkuNC0yNS44bDQyLjEtNDIuMWMyLTIgNC41LTMuMiA2LjgtNC41IDIuOSA5LjkgOCAxOS4zIDE1LjggMjcuMiAyNSAyNSA2NS42IDI0LjkgOTAuNSAwbDkwLjUtOTAuNWMyNS0yNSAyNS02NS42IDAtOTAuNSAtMjQuOS0yNS02NS41LTI1LTkwLjUgMGwtMzIuMiAzMi4yYy0yNi4xLTEwLjItNTQuMi0xMi45LTgxLjYtOC45bDY4LjYtNjguNmM1MC01MCAxMzEtNTAgMTgxIDBDNTA5LjYgMTAyLjMgNTA5LjYgMTgzLjQgNDU5LjcgMjMzLjR6TTIyMC4zIDM4Mi4ybC0zMi4yIDMyLjJjLTI1IDI0LjktNjUuNiAyNC45LTkwLjUgMCAtMjUtMjUtMjUtNjUuNiAwLTkwLjVsOTAuNS05MC41YzI1LTI1IDY1LjUtMjUgOTAuNSAwIDcuOCA3LjggMTIuOSAxNy4yIDE1LjggMjcuMSAyLjQtMS40IDQuOC0yLjUgNi44LTQuNWw0Mi4xLTQyYy01LjQtOS4yLTExLjYtMTgtMTkuNC0yNS44IC01MC01MC0xMzEtNTAtMTgxIDBsLTkwLjUgOTAuNWMtNTAgNTAtNTAgMTMxIDAgMTgxIDUwIDUwIDEzMSA1MCAxODEgMGw2OC42LTY4LjZDMjc0LjYgMzk1LjEgMjQ2LjQgMzkyLjMgMjIwLjMgMzgyLjJ6Ii8+PC9zdmc+Cg==');
+        opacity: 0.5;
+        visibility: hidden;
+        display: inline-block;
+        vertical-align: middle;
+      } /*!sc*/
+      .kbZred h1:hover > .share-link::before,
+      .kbZred h2:hover > .share-link::before,
+      .kbZred .share-link:hover::before {
+        visibility: visible;
+      } /*!sc*/
+      .kbZred a {
+        text-decoration: auto;
+        color: #32329f;
+      } /*!sc*/
+      .kbZred a:visited {
+        color: #32329f;
+      } /*!sc*/
+      .kbZred a:hover {
+        color: #6868cf;
+        text-decoration: auto;
+      } /*!sc*/
+      .drqpJr {
+        font-family: Roboto, sans-serif;
+        font-weight: 400;
+        line-height: 1.5em;
+      } /*!sc*/
+      .drqpJr p:last-child {
+        margin-bottom: 0;
+      } /*!sc*/
+      .drqpJr p:first-child {
+        margin-top: 0;
+      } /*!sc*/
+      .drqpJr p:last-child {
+        margin-bottom: 0;
+      } /*!sc*/
+      .drqpJr h1 {
+        font-family: Montserrat, sans-serif;
+        font-weight: 400;
+        font-size: 1.85714em;
+        line-height: 1.6em;
+        color: #32329f;
+        margin-top: 0;
+      } /*!sc*/
+      .drqpJr h2 {
+        font-family: Montserrat, sans-serif;
+        font-weight: 400;
+        font-size: 1.57143em;
+        line-height: 1.6em;
+        color: #333333;
+      } /*!sc*/
+      .drqpJr code {
+        color: #e53935;
+        background-color: rgba(38, 50, 56, 0.05);
+        font-family: Courier, monospace;
+        border-radius: 2px;
+        border: 1px solid rgba(38, 50, 56, 0.1);
+        padding: 0 5px;
+        font-size: 13px;
+        font-weight: 400;
+        word-break: break-word;
+      } /*!sc*/
+      .drqpJr pre {
+        font-family: Courier, monospace;
+        white-space: pre;
+        background-color: #11171a;
+        color: white;
+        padding: 20px;
+        overflow-x: auto;
+        line-height: normal;
+        border-radius: 0;
+        border: 1px solid rgba(38, 50, 56, 0.1);
+      } /*!sc*/
+      .drqpJr pre code {
+        background-color: transparent;
+        color: white;
+        padding: 0;
+      } /*!sc*/
+      .drqpJr pre code:before,
+      .drqpJr pre code:after {
+        content: none;
+      } /*!sc*/
+      .drqpJr blockquote {
+        margin: 0;
+        margin-bottom: 1em;
+        padding: 0 15px;
+        color: #777;
+        border-left: 4px solid #ddd;
+      } /*!sc*/
+      .drqpJr img {
+        max-width: 100%;
+        box-sizing: content-box;
+      } /*!sc*/
+      .drqpJr ul,
+      .drqpJr ol {
+        padding-left: 2em;
+        margin: 0;
+        margin-bottom: 1em;
+      } /*!sc*/
+      .drqpJr ul ul,
+      .drqpJr ol ul,
+      .drqpJr ul ol,
+      .drqpJr ol ol {
+        margin-bottom: 0;
+        margin-top: 0;
+      } /*!sc*/
+      .drqpJr table {
+        display: block;
+        width: 100%;
+        overflow: auto;
+        word-break: normal;
+        word-break: keep-all;
+        border-collapse: collapse;
+        border-spacing: 0;
+        margin-top: 1.5em;
+        margin-bottom: 1.5em;
+      } /*!sc*/
+      .drqpJr table tr {
+        background-color: #fff;
+        border-top: 1px solid #ccc;
+      } /*!sc*/
+      .drqpJr table tr:nth-child(2n) {
+        background-color: #fafafa;
+      } /*!sc*/
+      .drqpJr table th,
+      .drqpJr table td {
+        padding: 6px 13px;
+        border: 1px solid #ddd;
+      } /*!sc*/
+      .drqpJr table th {
+        text-align: left;
+        font-weight: bold;
+      } /*!sc*/
+      .drqpJr .share-link {
+        cursor: pointer;
+        margin-left: -20px;
+        padding: 0;
+        line-height: 1;
+        width: 20px;
+        display: inline-block;
+        outline: 0;
+      } /*!sc*/
+      .drqpJr .share-link:before {
+        content: '';
+        width: 15px;
+        height: 15px;
+        background-size: contain;
+        background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZlcnNpb249IjEuMSIgeD0iMCIgeT0iMCIgd2lkdGg9IjUxMiIgaGVpZ2h0PSI1MTIiIHZpZXdCb3g9IjAgMCA1MTIgNTEyIiBlbmFibGUtYmFja2dyb3VuZD0ibmV3IDAgMCA1MTIgNTEyIiB4bWw6c3BhY2U9InByZXNlcnZlIj48cGF0aCBmaWxsPSIjMDEwMTAxIiBkPSJNNDU5LjcgMjMzLjRsLTkwLjUgOTAuNWMtNTAgNTAtMTMxIDUwLTE4MSAwIC03LjktNy44LTE0LTE2LjctMTkuNC0yNS44bDQyLjEtNDIuMWMyLTIgNC41LTMuMiA2LjgtNC41IDIuOSA5LjkgOCAxOS4zIDE1LjggMjcuMiAyNSAyNSA2NS42IDI0LjkgOTAuNSAwbDkwLjUtOTAuNWMyNS0yNSAyNS02NS42IDAtOTAuNSAtMjQuOS0yNS02NS41LTI1LTkwLjUgMGwtMzIuMiAzMi4yYy0yNi4xLTEwLjItNTQuMi0xMi45LTgxLjYtOC45bDY4LjYtNjguNmM1MC01MCAxMzEtNTAgMTgxIDBDNTA5LjYgMTAyLjMgNTA5LjYgMTgzLjQgNDU5LjcgMjMzLjR6TTIyMC4zIDM4Mi4ybC0zMi4yIDMyLjJjLTI1IDI0LjktNjUuNiAyNC45LTkwLjUgMCAtMjUtMjUtMjUtNjUuNiAwLTkwLjVsOTAuNS05MC41YzI1LTI1IDY1LjUtMjUgOTAuNSAwIDcuOCA3LjggMTIuOSAxNy4yIDE1LjggMjcuMSAyLjQtMS40IDQuOC0yLjUgNi44LTQuNWw0Mi4xLTQyYy01LjQtOS4yLTExLjYtMTgtMTkuNC0yNS44IC01MC01MC0xMzEtNTAtMTgxIDBsLTkwLjUgOTAuNWMtNTAgNTAtNTAgMTMxIDAgMTgxIDUwIDUwIDEzMSA1MCAxODEgMGw2OC42LTY4LjZDMjc0LjYgMzk1LjEgMjQ2LjQgMzkyLjMgMjIwLjMgMzgyLjJ6Ii8+PC9zdmc+Cg==');
+        opacity: 0.5;
+        visibility: hidden;
+        display: inline-block;
+        vertical-align: middle;
+      } /*!sc*/
+      .drqpJr h1:hover > .share-link::before,
+      .drqpJr h2:hover > .share-link::before,
+      .drqpJr .share-link:hover::before {
+        visibility: visible;
+      } /*!sc*/
+      .drqpJr a {
+        text-decoration: auto;
+        color: #32329f;
+      } /*!sc*/
+      .drqpJr a:visited {
+        color: #32329f;
+      } /*!sc*/
+      .drqpJr a:hover {
+        color: #6868cf;
+        text-decoration: auto;
+      } /*!sc*/
+      .jnwENr {
+        font-family: Roboto, sans-serif;
+        font-weight: 400;
+        line-height: 1.5em;
+      } /*!sc*/
+      .jnwENr p:last-child {
+        margin-bottom: 0;
+      } /*!sc*/
+      .jnwENr p:first-child {
+        margin-top: 0;
+      } /*!sc*/
+      .jnwENr p:last-child {
+        margin-bottom: 0;
+      } /*!sc*/
+      .jnwENr p {
+        display: inline-block;
+      } /*!sc*/
+      .jnwENr h1 {
+        font-family: Montserrat, sans-serif;
+        font-weight: 400;
+        font-size: 1.85714em;
+        line-height: 1.6em;
+        color: #32329f;
+        margin-top: 0;
+      } /*!sc*/
+      .jnwENr h2 {
+        font-family: Montserrat, sans-serif;
+        font-weight: 400;
+        font-size: 1.57143em;
+        line-height: 1.6em;
+        color: #333333;
+      } /*!sc*/
+      .jnwENr code {
+        color: #e53935;
+        background-color: rgba(38, 50, 56, 0.05);
+        font-family: Courier, monospace;
+        border-radius: 2px;
+        border: 1px solid rgba(38, 50, 56, 0.1);
+        padding: 0 5px;
+        font-size: 13px;
+        font-weight: 400;
+        word-break: break-word;
+      } /*!sc*/
+      .jnwENr pre {
+        font-family: Courier, monospace;
+        white-space: pre;
+        background-color: #11171a;
+        color: white;
+        padding: 20px;
+        overflow-x: auto;
+        line-height: normal;
+        border-radius: 0;
+        border: 1px solid rgba(38, 50, 56, 0.1);
+      } /*!sc*/
+      .jnwENr pre code {
+        background-color: transparent;
+        color: white;
+        padding: 0;
+      } /*!sc*/
+      .jnwENr pre code:before,
+      .jnwENr pre code:after {
+        content: none;
+      } /*!sc*/
+      .jnwENr blockquote {
+        margin: 0;
+        margin-bottom: 1em;
+        padding: 0 15px;
+        color: #777;
+        border-left: 4px solid #ddd;
+      } /*!sc*/
+      .jnwENr img {
+        max-width: 100%;
+        box-sizing: content-box;
+      } /*!sc*/
+      .jnwENr ul,
+      .jnwENr ol {
+        padding-left: 2em;
+        margin: 0;
+        margin-bottom: 1em;
+      } /*!sc*/
+      .jnwENr ul ul,
+      .jnwENr ol ul,
+      .jnwENr ul ol,
+      .jnwENr ol ol {
+        margin-bottom: 0;
+        margin-top: 0;
+      } /*!sc*/
+      .jnwENr table {
+        display: block;
+        width: 100%;
+        overflow: auto;
+        word-break: normal;
+        word-break: keep-all;
+        border-collapse: collapse;
+        border-spacing: 0;
+        margin-top: 1.5em;
+        margin-bottom: 1.5em;
+      } /*!sc*/
+      .jnwENr table tr {
+        background-color: #fff;
+        border-top: 1px solid #ccc;
+      } /*!sc*/
+      .jnwENr table tr:nth-child(2n) {
+        background-color: #fafafa;
+      } /*!sc*/
+      .jnwENr table th,
+      .jnwENr table td {
+        padding: 6px 13px;
+        border: 1px solid #ddd;
+      } /*!sc*/
+      .jnwENr table th {
+        text-align: left;
+        font-weight: bold;
+      } /*!sc*/
+      .jnwENr .share-link {
+        cursor: pointer;
+        margin-left: -20px;
+        padding: 0;
+        line-height: 1;
+        width: 20px;
+        display: inline-block;
+        outline: 0;
+      } /*!sc*/
+      .jnwENr .share-link:before {
+        content: '';
+        width: 15px;
+        height: 15px;
+        background-size: contain;
+        background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZlcnNpb249IjEuMSIgeD0iMCIgeT0iMCIgd2lkdGg9IjUxMiIgaGVpZ2h0PSI1MTIiIHZpZXdCb3g9IjAgMCA1MTIgNTEyIiBlbmFibGUtYmFja2dyb3VuZD0ibmV3IDAgMCA1MTIgNTEyIiB4bWw6c3BhY2U9InByZXNlcnZlIj48cGF0aCBmaWxsPSIjMDEwMTAxIiBkPSJNNDU5LjcgMjMzLjRsLTkwLjUgOTAuNWMtNTAgNTAtMTMxIDUwLTE4MSAwIC03LjktNy44LTE0LTE2LjctMTkuNC0yNS44bDQyLjEtNDIuMWMyLTIgNC41LTMuMiA2LjgtNC41IDIuOSA5LjkgOCAxOS4zIDE1LjggMjcuMiAyNSAyNSA2NS42IDI0LjkgOTAuNSAwbDkwLjUtOTAuNWMyNS0yNSAyNS02NS42IDAtOTAuNSAtMjQuOS0yNS02NS41LTI1LTkwLjUgMGwtMzIuMiAzMi4yYy0yNi4xLTEwLjItNTQuMi0xMi45LTgxLjYtOC45bDY4LjYtNjguNmM1MC01MCAxMzEtNTAgMTgxIDBDNTA5LjYgMTAyLjMgNTA5LjYgMTgzLjQgNDU5LjcgMjMzLjR6TTIyMC4zIDM4Mi4ybC0zMi4yIDMyLjJjLTI1IDI0LjktNjUuNiAyNC45LTkwLjUgMCAtMjUtMjUtMjUtNjUuNiAwLTkwLjVsOTAuNS05MC41YzI1LTI1IDY1LjUtMjUgOTAuNSAwIDcuOCA3LjggMTIuOSAxNy4yIDE1LjggMjcuMSAyLjQtMS40IDQuOC0yLjUgNi44LTQuNWw0Mi4xLTQyYy01LjQtOS4yLTExLjYtMTgtMTkuNC0yNS44IC01MC01MC0xMzEtNTAtMTgxIDBsLTkwLjUgOTAuNWMtNTAgNTAtNTAgMTMxIDAgMTgxIDUwIDUwIDEzMSA1MCAxODEgMGw2OC42LTY4LjZDMjc0LjYgMzk1LjEgMjQ2LjQgMzkyLjMgMjIwLjMgMzgyLjJ6Ii8+PC9zdmc+Cg==');
+        opacity: 0.5;
+        visibility: hidden;
+        display: inline-block;
+        vertical-align: middle;
+      } /*!sc*/
+      .jnwENr h1:hover > .share-link::before,
+      .jnwENr h2:hover > .share-link::before,
+      .jnwENr .share-link:hover::before {
+        visibility: visible;
+      } /*!sc*/
+      .jnwENr a {
+        text-decoration: auto;
+        color: #32329f;
+      } /*!sc*/
+      .jnwENr a:visited {
+        color: #32329f;
+      } /*!sc*/
+      .jnwENr a:hover {
+        color: #6868cf;
+        text-decoration: auto;
+      } /*!sc*/
+      data-styled.g42[id='sc-fszimp'] {
+        content: 'kbZred,drqpJr,jnwENr,';
+      } /*!sc*/
+      .ljKHqG {
+        display: inline;
+      } /*!sc*/
+      data-styled.g43[id='sc-etsjJW'] {
+        content: 'ljKHqG,';
+      } /*!sc*/
+      .iNCOCX {
+        position: relative;
+      } /*!sc*/
+      data-styled.g44[id='sc-fYmhhH'] {
+        content: 'iNCOCX,';
+      } /*!sc*/
+      .fdRrNy:hover > .sc-bbbBoY {
+        opacity: 1;
+      } /*!sc*/
+      data-styled.g49[id='sc-dClGHI'] {
+        content: 'fdRrNy,';
+      } /*!sc*/
+      .dFvLDb {
+        font-family: Courier, monospace;
+        font-size: 13px;
+        white-space: pre;
+        contain: content;
+        overflow-x: auto;
+      } /*!sc*/
+      .dFvLDb .redoc-json code > .collapser {
+        display: none;
+        pointer-events: none;
+      } /*!sc*/
+      .dFvLDb .callback-function {
+        color: gray;
+      } /*!sc*/
+      .dFvLDb .collapser:after {
+        content: '-';
+        cursor: pointer;
+      } /*!sc*/
+      .dFvLDb .collapsed > .collapser:after {
+        content: '+';
+        cursor: pointer;
+      } /*!sc*/
+      .dFvLDb .ellipsis:after {
+        content: ' … ';
+      } /*!sc*/
+      .dFvLDb .collapsible {
+        margin-left: 2em;
+      } /*!sc*/
+      .dFvLDb .hoverable {
+        padding-top: 1px;
+        padding-bottom: 1px;
+        padding-left: 2px;
+        padding-right: 2px;
+        border-radius: 2px;
+      } /*!sc*/
+      .dFvLDb .hovered {
+        background-color: rgba(235, 238, 249, 1);
+      } /*!sc*/
+      .dFvLDb .collapser {
+        background-color: transparent;
+        border: 0;
+        color: #fff;
+        font-family: Courier, monospace;
+        font-size: 13px;
+        padding-right: 6px;
+        padding-left: 6px;
+        padding-top: 0;
+        padding-bottom: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 15px;
+        height: 15px;
+        position: absolute;
+        top: 4px;
+        left: -1.5em;
+        cursor: default;
+        user-select: none;
+        -webkit-user-select: none;
+        padding: 2px;
+      } /*!sc*/
+      .dFvLDb .collapser:focus {
+        outline-color: #fff;
+        outline-style: dotted;
+        outline-width: 1px;
+      } /*!sc*/
+      .dFvLDb ul {
+        list-style-type: none;
+        padding: 0px;
+        margin: 0px 0px 0px 26px;
+      } /*!sc*/
+      .dFvLDb li {
+        position: relative;
+        display: block;
+      } /*!sc*/
+      .dFvLDb .hoverable {
+        display: inline-block;
+      } /*!sc*/
+      .dFvLDb .selected {
+        outline-style: solid;
+        outline-width: 1px;
+        outline-style: dotted;
+      } /*!sc*/
+      .dFvLDb .collapsed > .collapsible {
+        display: none;
+      } /*!sc*/
+      .dFvLDb .ellipsis {
+        display: none;
+      } /*!sc*/
+      .dFvLDb .collapsed > .ellipsis {
+        display: inherit;
+      } /*!sc*/
+      data-styled.g50[id='sc-fhfEft'] {
+        content: 'dFvLDb,';
+      } /*!sc*/
+      .iNRAJK {
+        padding: 0.9em;
+        background-color: rgba(38, 50, 56, 0.4);
+        margin: 0 0 10px 0;
+        display: block;
+        font-family: Montserrat, sans-serif;
+        font-size: 0.929em;
+        line-height: 1.5em;
+      } /*!sc*/
+      data-styled.g51[id='sc-bAehkN'] {
+        content: 'iNRAJK,';
+      } /*!sc*/
+      .cXitJ {
+        font-family: Montserrat, sans-serif;
+        font-size: 12px;
+        position: absolute;
+        z-index: 1;
+        top: -11px;
+        left: 12px;
+        font-weight: 600;
+        color: rgba(255, 255, 255, 0.7);
+      } /*!sc*/
+      data-styled.g52[id='sc-gahYZc'] {
+        content: 'cXitJ,';
+      } /*!sc*/
+      .iLdyBp {
+        position: relative;
+      } /*!sc*/
+      data-styled.g53[id='sc-bSFBcf'] {
+        content: 'iLdyBp,';
+      } /*!sc*/
+      .eKKwxo {
+        margin-top: 15px;
+      } /*!sc*/
+      data-styled.g56[id='sc-blIAwI'] {
+        content: 'eKKwxo,';
+      } /*!sc*/
+      .lhyyLL {
+        vertical-align: middle;
+        font-size: 13px;
+        line-height: 20px;
+      } /*!sc*/
+      data-styled.g58[id='sc-bEjUoa'] {
+        content: 'lhyyLL,';
+      } /*!sc*/
+      .jYezsP {
+        color: rgba(102, 102, 102, 0.9);
+      } /*!sc*/
+      data-styled.g59[id='sc-boKDdR'] {
+        content: 'jYezsP,';
+      } /*!sc*/
+      .dbKJYq {
+        color: #666;
+      } /*!sc*/
+      data-styled.g60[id='sc-fOOuSg'] {
+        content: 'dbKJYq,';
+      } /*!sc*/
+      .crXmiY {
+        color: #d41f1c;
+        font-size: 0.9em;
+        font-weight: normal;
+        margin-left: 20px;
+        line-height: 1;
+      } /*!sc*/
+      data-styled.g62[id='sc-iIvHqT'] {
+        content: 'crXmiY,';
+      } /*!sc*/
+      .kMQdIk {
+        border-radius: 2px;
+        word-break: break-word;
+        background-color: rgba(51, 51, 51, 0.05);
+        color: rgba(51, 51, 51, 0.9);
+        padding: 0 5px;
+        border: 1px solid rgba(51, 51, 51, 0.1);
+        font-family: Courier, monospace;
+      } /*!sc*/
+      + {
+        margin-left: 0;
+      } /*!sc*/
+      data-styled.g66[id='sc-dTWiOz'] {
+        content: 'kMQdIk,';
+      } /*!sc*/
+      .bDfgbe {
+        border-radius: 2px;
+        background-color: rgba(104, 104, 207, 0.05);
+        color: rgba(50, 50, 159, 0.9);
+        margin: 0 5px;
+        padding: 0 5px;
+        border: 1px solid rgba(50, 50, 159, 0.1);
+      } /*!sc*/
+      + {
+        margin-left: 0;
+      } /*!sc*/
+      data-styled.g68[id='sc-goiVcJ'] {
+        content: 'bDfgbe,';
+      } /*!sc*/
+      .hRtRoN:after {
+        content: ' and ';
+        font-weight: normal;
+      } /*!sc*/
+      .hRtRoN:last-child:after {
+        content: none;
+      } /*!sc*/
+      .hRtRoN a {
+        text-decoration: auto;
+        color: #32329f;
+      } /*!sc*/
+      .hRtRoN a:visited {
+        color: #32329f;
+      } /*!sc*/
+      .hRtRoN a:hover {
+        color: #6868cf;
+        text-decoration: auto;
+      } /*!sc*/
+      data-styled.g81[id='sc-hqtLyI'] {
+        content: 'hRtRoN,';
+      } /*!sc*/
+      .gRXavu {
+        white-space: nowrap;
+      } /*!sc*/
+      .gRXavu:after {
+        content: ' or ';
+        white-space: pre;
+      } /*!sc*/
+      .gRXavu:last-child:after,
+      .gRXavu:only-child:after {
+        content: none;
+      } /*!sc*/
+      .gRXavu a {
+        text-decoration: auto;
+        color: #32329f;
+      } /*!sc*/
+      .gRXavu a:visited {
+        color: #32329f;
+      } /*!sc*/
+      .gRXavu a:hover {
+        color: #6868cf;
+        text-decoration: auto;
+      } /*!sc*/
+      data-styled.g82[id='sc-iVnIWt'] {
+        content: 'gRXavu,';
+      } /*!sc*/
+      .dPSGXF {
+        flex: 1 1 auto;
+        cursor: pointer;
+      } /*!sc*/
+      data-styled.g83[id='sc-hWgKua'] {
+        content: 'dPSGXF,';
+      } /*!sc*/
+      .fUkQtw {
+        width: 75%;
+        text-overflow: ellipsis;
+        border-radius: 4px;
+        overflow: hidden;
+      } /*!sc*/
+      @media screen and (max-width: 50rem) {
+        .fUkQtw {
+          margin-top: 10px;
+        }
+      } /*!sc*/
+      data-styled.g84[id='sc-jBaHRL'] {
+        content: 'fUkQtw,';
+      } /*!sc*/
+      .jCoZLr {
+        display: inline-block;
+        margin: 0;
+      } /*!sc*/
+      data-styled.g85[id='sc-gFqXPY'] {
+        content: 'jCoZLr,';
+      } /*!sc*/
+      .deUlC {
+        width: 100%;
+        display: flex;
+        margin: 1em 0;
+        flex-direction: row;
+      } /*!sc*/
+      @media screen and (max-width: 50rem) {
+        .deUlC {
+          flex-direction: column;
+        }
+      } /*!sc*/
+      data-styled.g86[id='sc-ikkVnJ'] {
+        content: 'deUlC,';
+      } /*!sc*/
+      .hPcPCj {
+        margin-top: 0;
+        margin-bottom: 0.5em;
+      } /*!sc*/
+      data-styled.g92[id='sc-jCWzJg'] {
+        content: 'hPcPCj,';
+      } /*!sc*/
+      .boxHVJ {
+        max-height: 260px;
+        max-width: 260px;
+        padding: 2px;
+        width: 100%;
+        display: block;
+      } /*!sc*/
+      data-styled.g97[id='sc-eKrodz'] {
+        content: 'boxHVJ,';
+      } /*!sc*/
+      .eWuUlW {
+        text-align: center;
+      } /*!sc*/
+      data-styled.g98[id='sc-jkvfRO'] {
+        content: 'eWuUlW,';
+      } /*!sc*/
+      .NmQLu {
+        width: 9ex;
+        display: inline-block;
+        height: 13px;
+        line-height: 13px;
+        background-color: #333;
+        border-radius: 3px;
+        background-repeat: no-repeat;
+        background-position: 6px 4px;
+        font-size: 7px;
+        font-family: Verdana, sans-serif;
+        color: white;
+        text-transform: uppercase;
+        text-align: center;
+        font-weight: bold;
+        vertical-align: middle;
+        margin-right: 6px;
+        margin-top: 2px;
+      } /*!sc*/
+      .NmQLu.get {
+        background-color: #2f8132;
+      } /*!sc*/
+      .NmQLu.post {
+        background-color: #186faf;
+      } /*!sc*/
+      .NmQLu.put {
+        background-color: #95507c;
+      } /*!sc*/
+      .NmQLu.options {
+        background-color: #947014;
+      } /*!sc*/
+      .NmQLu.patch {
+        background-color: #bf581d;
+      } /*!sc*/
+      .NmQLu.delete {
+        background-color: #cc3333;
+      } /*!sc*/
+      .NmQLu.basic {
+        background-color: #707070;
+      } /*!sc*/
+      .NmQLu.link {
+        background-color: #07818f;
+      } /*!sc*/
+      .NmQLu.head {
+        background-color: #a23dad;
+      } /*!sc*/
+      .NmQLu.hook {
+        background-color: #32329f;
+      } /*!sc*/
+      .NmQLu.schema {
+        background-color: #707070;
+      } /*!sc*/
+      data-styled.g100[id='sc-jxYSNo'] {
+        content: 'NmQLu,';
+      } /*!sc*/
+      .gAPKXX {
+        margin: 0;
+        padding: 0;
+      } /*!sc*/
+      .gAPKXX:first-child {
+        padding-bottom: 32px;
+      } /*!sc*/
+      .sc-zOxLx .sc-zOxLx {
+        font-size: 0.929em;
+      } /*!sc*/
+      .dQnkdy {
+        margin: 0;
+        padding: 0;
+        display: none;
+      } /*!sc*/
+      .dQnkdy:first-child {
+        padding-bottom: 32px;
+      } /*!sc*/
+      .sc-zOxLx .sc-zOxLx {
+        font-size: 0.929em;
+      } /*!sc*/
+      data-styled.g101[id='sc-zOxLx'] {
+        content: 'gAPKXX,dQnkdy,';
+      } /*!sc*/
+      .ixknQI {
+        list-style: none inside none;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        padding: 0;
+      } /*!sc*/
+      data-styled.g102[id='sc-cgHfjM'] {
+        content: 'ixknQI,';
+      } /*!sc*/
+      .lgPGwq {
+        cursor: pointer;
+        color: #333333;
+        margin: 0;
+        padding: 12.5px 20px;
+        display: flex;
+        justify-content: space-between;
+        font-family: Montserrat, sans-serif;
+        font-size: 0.929em;
+        text-transform: none;
+        background-color: #fafafa;
+      } /*!sc*/
+      .lgPGwq:hover {
+        color: #32329f;
+        background-color: #e1e1e1;
+      } /*!sc*/
+      .lgPGwq .sc-dntSTA {
+        height: 1.5em;
+        width: 1.5em;
+      } /*!sc*/
+      .lgPGwq .sc-dntSTA polygon {
+        fill: #333333;
+      } /*!sc*/
+      .iHRgeo {
+        cursor: pointer;
+        color: #333333;
+        margin: 0;
+        padding: 12.5px 20px;
+        display: flex;
+        justify-content: space-between;
+        font-family: Montserrat, sans-serif;
+        background-color: #fafafa;
+      } /*!sc*/
+      .iHRgeo:hover {
+        color: #32329f;
+        background-color: #ededed;
+      } /*!sc*/
+      .iHRgeo .sc-dntSTA {
+        height: 1.5em;
+        width: 1.5em;
+      } /*!sc*/
+      .iHRgeo .sc-dntSTA polygon {
+        fill: #333333;
+      } /*!sc*/
+      data-styled.g103[id='sc-fpikKz'] {
+        content: 'lgPGwq,iHRgeo,';
+      } /*!sc*/
+      .cxcra {
+        display: inline-block;
+        vertical-align: middle;
+        width: calc(100% - 38px);
+        overflow: hidden;
+        text-overflow: ellipsis;
+      } /*!sc*/
+      data-styled.g104[id='sc-gWaSiO'] {
+        content: 'cxcra,';
+      } /*!sc*/
+      .QuyG {
+        font-size: 0.8em;
+        margin-top: 10px;
+        text-align: center;
+        position: fixed;
+        width: 260px;
+        bottom: 0;
+        background: #fafafa;
+      } /*!sc*/
+      .QuyG a,
+      .QuyG a:visited,
+      .QuyG a:hover {
+        color: #333333 !important;
+        padding: 5px 0;
+        border-top: 1px solid #e1e1e1;
+        text-decoration: none;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      } /*!sc*/
+      .QuyG img {
+        width: 15px;
+        margin-right: 5px;
+      } /*!sc*/
+      @media screen and (max-width: 50rem) {
+        .QuyG {
+          width: 100%;
+        }
+      } /*!sc*/
+      data-styled.g105[id='sc-kSaXSp'] {
+        content: 'QuyG,';
+      } /*!sc*/
+      .jjnszm {
+        cursor: pointer;
+        position: relative;
+        margin-bottom: 5px;
+      } /*!sc*/
+      data-styled.g111[id='sc-eZSpzM'] {
+        content: 'jjnszm,';
+      } /*!sc*/
+      .kZcHWP {
+        font-family: Courier, monospace;
+        margin-left: 10px;
+        flex: 1;
+        overflow-x: hidden;
+        text-overflow: ellipsis;
+      } /*!sc*/
+      data-styled.g112[id='sc-jvKoal'] {
+        content: 'kZcHWP,';
+      } /*!sc*/
+      .iPCVMX {
+        outline: 0;
+        color: inherit;
+        width: 100%;
+        text-align: left;
+        cursor: pointer;
+        padding: 10px 30px 10px 20px;
+        border-radius: 4px 4px 0 0;
+        background-color: #11171a;
+        display: flex;
+        white-space: nowrap;
+        align-items: center;
+        border: 1px solid transparent;
+        border-bottom: 0;
+        transition: border-color 0.25s ease;
+      } /*!sc*/
+      .iPCVMX ..sc-jvKoal {
+        color: #ffffff;
+      } /*!sc*/
+      .iPCVMX:focus {
+        box-shadow:
+          inset 0 2px 2px rgba(0, 0, 0, 0.45),
+          0 2px 0 rgba(128, 128, 128, 0.25);
+      } /*!sc*/
+      data-styled.g113[id='sc-buTqWO'] {
+        content: 'iPCVMX,';
+      } /*!sc*/
+      .kwcmyC {
+        font-size: 0.929em;
+        line-height: 20px;
+        background-color: #186faf;
+        color: #ffffff;
+        padding: 3px 10px;
+        text-transform: uppercase;
+        font-family: Montserrat, sans-serif;
+        margin: 0;
+      } /*!sc*/
+      .dynMBc {
+        font-size: 0.929em;
+        line-height: 20px;
+        background-color: #2f8132;
+        color: #ffffff;
+        padding: 3px 10px;
+        text-transform: uppercase;
+        font-family: Montserrat, sans-serif;
+        margin: 0;
+      } /*!sc*/
+      .gKcHYQ {
+        font-size: 0.929em;
+        line-height: 20px;
+        background-color: #cc3333;
+        color: #ffffff;
+        padding: 3px 10px;
+        text-transform: uppercase;
+        font-family: Montserrat, sans-serif;
+        margin: 0;
+      } /*!sc*/
+      data-styled.g114[id='sc-fQLpxn'] {
+        content: 'kwcmyC,dynMBc,gKcHYQ,';
+      } /*!sc*/
+      .ga-DQLq {
+        position: absolute;
+        width: 100%;
+        z-index: 100;
+        background: #fafafa;
+        color: #263238;
+        box-sizing: border-box;
+        box-shadow: 0 0 6px rgba(0, 0, 0, 0.33);
+        overflow: hidden;
+        border-bottom-left-radius: 4px;
+        border-bottom-right-radius: 4px;
+        transition: all 0.25s ease;
+        visibility: hidden;
+        transform: translateY(-50%) scaleY(0);
+      } /*!sc*/
+      data-styled.g115[id='sc-ecJghI'] {
+        content: 'ga-DQLq,';
+      } /*!sc*/
+      .icOxsG {
+        padding: 10px;
+      } /*!sc*/
+      data-styled.g116[id='sc-iyBeIh'] {
+        content: 'icOxsG,';
+      } /*!sc*/
+      .okJpy {
+        padding: 5px;
+        border: 1px solid #ccc;
+        background: #fff;
+        word-break: break-all;
+        color: #32329f;
+      } /*!sc*/
+      .okJpy > span {
+        color: #333333;
+      } /*!sc*/
+      data-styled.g117[id='sc-xKhEK'] {
+        content: 'okJpy,';
+      } /*!sc*/
+      .foplsk {
+        text-transform: lowercase;
+        margin-left: 0;
+        line-height: 1.5em;
+      } /*!sc*/
+      data-styled.g118[id='sc-eTCgfj'] {
+        content: 'foplsk,';
+      } /*!sc*/
+      .lkmdtA {
+        display: block;
+        border: 0;
+        width: 100%;
+        text-align: left;
+        padding: 10px;
+        border-radius: 2px;
+        margin-bottom: 4px;
+        line-height: 1.5em;
+        cursor: pointer;
+        color: #1d8127;
+        background-color: rgba(29, 129, 39, 0.07);
+      } /*!sc*/
+      .lkmdtA:focus {
+        outline: auto #1d8127;
+      } /*!sc*/
+      .ifAHvq {
+        display: block;
+        border: 0;
+        width: 100%;
+        text-align: left;
+        padding: 10px;
+        border-radius: 2px;
+        margin-bottom: 4px;
+        line-height: 1.5em;
+        cursor: pointer;
+        color: #d41f1c;
+        background-color: rgba(212, 31, 28, 0.07);
+      } /*!sc*/
+      .ifAHvq:focus {
+        outline: auto #d41f1c;
+      } /*!sc*/
+      .kQCDrg {
+        display: block;
+        border: 0;
+        width: 100%;
+        text-align: left;
+        padding: 10px;
+        border-radius: 2px;
+        margin-bottom: 4px;
+        line-height: 1.5em;
+        cursor: pointer;
+        color: #d41f1c;
+        background-color: rgba(212, 31, 28, 0.07);
+        cursor: default;
+      } /*!sc*/
+      .kQCDrg:focus {
+        outline: auto #d41f1c;
+      } /*!sc*/
+      .kQCDrg::before {
+        content: '—';
+        font-weight: bold;
+        width: 1.5em;
+        text-align: center;
+        display: inline-block;
+        vertical-align: top;
+      } /*!sc*/
+      .kQCDrg:focus {
+        outline: 0;
+      } /*!sc*/
+      data-styled.g120[id='sc-jIDBmd'] {
+        content: 'lkmdtA,ifAHvq,kQCDrg,';
+      } /*!sc*/
+      .fBhAXU {
+        vertical-align: top;
+      } /*!sc*/
+      data-styled.g123[id='sc-eJvlPh'] {
+        content: 'fBhAXU,';
+      } /*!sc*/
+      .kjrVcG {
+        font-size: 1.3em;
+        padding: 0.2em 0;
+        margin: 3em 0 1.1em;
+        color: #333333;
+        font-weight: normal;
+      } /*!sc*/
+      data-styled.g124[id='sc-gDzyrw'] {
+        content: 'kjrVcG,';
+      } /*!sc*/
+      .crXcHD {
+        user-select: none;
+        width: 20px;
+        height: 20px;
+        align-self: center;
+        display: flex;
+        flex-direction: column;
+        color: #32329f;
+      } /*!sc*/
+      data-styled.g130[id='sc-cZnrqW'] {
+        content: 'crXcHD,';
+      } /*!sc*/
+      .dsiHUZ {
+        width: 260px;
+        background-color: #fafafa;
+        overflow: hidden;
+        display: flex;
+        flex-direction: column;
+        backface-visibility: hidden;
+        height: 100vh;
+        position: sticky;
+        position: -webkit-sticky;
+        top: 0;
+      } /*!sc*/
+      @media screen and (max-width: 50rem) {
+        .dsiHUZ {
+          position: fixed;
+          z-index: 20;
+          width: 100%;
+          background: #fafafa;
+          display: none;
+        }
+      } /*!sc*/
+      @media print {
+        .dsiHUZ {
+          display: none;
+        }
+      } /*!sc*/
+      data-styled.g131[id='sc-fstJre'] {
+        content: 'dsiHUZ,';
+      } /*!sc*/
+      .bovaLG {
+        outline: none;
+        user-select: none;
+        background-color: #f2f2f2;
+        color: #32329f;
+        display: none;
+        cursor: pointer;
+        position: fixed;
+        right: 20px;
+        z-index: 100;
+        border-radius: 50%;
+        box-shadow: 0 0 20px rgba(0, 0, 0, 0.3);
+        bottom: 44px;
+        width: 60px;
+        height: 60px;
+        padding: 0 20px;
+      } /*!sc*/
+      @media screen and (max-width: 50rem) {
+        .bovaLG {
+          display: flex;
+        }
+      } /*!sc*/
+      .bovaLG svg {
+        color: #0065fb;
+      } /*!sc*/
+      @media print {
+        .bovaLG {
+          display: none;
+        }
+      } /*!sc*/
+      data-styled.g132[id='sc-jOlHRD'] {
+        content: 'bovaLG,';
+      } /*!sc*/
+      .eHdqcJ {
+        font-family: Roboto, sans-serif;
+        font-size: 14px;
+        font-weight: 400;
+        line-height: 1.5em;
+        color: #333333;
+        display: flex;
+        position: relative;
+        text-align: left;
+        -webkit-font-smoothing: antialiased;
+        font-smoothing: antialiased;
+        text-rendering: optimizeSpeed !important;
+        tap-highlight-color: rgba(0, 0, 0, 0);
+        text-size-adjust: 100%;
+      } /*!sc*/
+      .eHdqcJ * {
+        box-sizing: border-box;
+        -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
+      } /*!sc*/
+      data-styled.g133[id='sc-Pgsbw'] {
+        content: 'eHdqcJ,';
+      } /*!sc*/
+      .buanwU {
+        z-index: 1;
+        position: relative;
+        overflow: hidden;
+        width: calc(100% - 260px);
+        contain: layout;
+      } /*!sc*/
+      @media print, screen and (max-width: 50rem) {
+        .buanwU {
+          width: 100%;
+        }
+      } /*!sc*/
+      data-styled.g134[id='sc-fkYqBV'] {
+        content: 'buanwU,';
+      } /*!sc*/
+      .iZqpqg {
+        background: #263238;
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        right: 0;
+        width: calc((100% - 260px) * 0.4);
+      } /*!sc*/
+      @media print, screen and (max-width: 75rem) {
+        .iZqpqg {
+          display: none;
+        }
+      } /*!sc*/
+      data-styled.g135[id='sc-evkzZa'] {
+        content: 'iZqpqg,';
+      } /*!sc*/
+      .gzMPIt {
+        padding: 5px 0;
+      } /*!sc*/
+      data-styled.g136[id='sc-iRcyzz'] {
+        content: 'gzMPIt,';
+      } /*!sc*/
+      .iOkeQy {
+        width: calc(100% - 40px);
+        box-sizing: border-box;
+        margin: 0 20px;
+        padding: 5px 10px 5px 20px;
+        border: 0;
+        border-bottom: 1px solid #e1e1e1;
+        font-family: Roboto, sans-serif;
+        font-weight: bold;
+        font-size: 13px;
+        color: #333333;
+        background-color: transparent;
+        outline: none;
+      } /*!sc*/
+      data-styled.g137[id='sc-lhsSio'] {
+        content: 'iOkeQy,';
+      } /*!sc*/
+      .SikXG {
+        position: absolute;
+        left: 20px;
+        height: 1.8em;
+        width: 0.9em;
+      } /*!sc*/
+      .SikXG path {
+        fill: #333333;
+      } /*!sc*/
+      data-styled.g138[id='sc-enPhjR'] {
+        content: 'SikXG,';
+      } /*!sc*/
+    </style>
+    <link
+      href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700"
+      rel="stylesheet"
+    />
+  </head>
+
+  <body>
+    <div id="redoc">
+      <link rel="preload" as="image" href="https://your-api-domain.com/logo.png" />
+      <div class="sc-Pgsbw eHdqcJ redoc-wrap">
+        <div class="sc-fstJre dsiHUZ menu-content" style="top: 0px; height: calc(100vh - 0px)">
+          <div class="sc-jkvfRO eWuUlW">
+            <img
+              src="https://your-api-domain.com/logo.png"
+              alt="Admin API Logo"
+              class="sc-eKrodz boxHVJ"
+            />
+          </div>
+          <div role="search" class="sc-iRcyzz gzMPIt">
+            <svg
+              class="sc-enPhjR SikXG search-icon"
+              version="1.1"
+              viewBox="0 0 1000 1000"
+              x="0px"
+              xmlns="http://www.w3.org/2000/svg"
+              y="0px"
+            >
+              <path
+                d="M968.2,849.4L667.3,549c83.9-136.5,66.7-317.4-51.7-435.6C477.1-25,252.5-25,113.9,113.4c-138.5,138.3-138.5,362.6,0,501C219.2,730.1,413.2,743,547.6,666.5l301.9,301.4c43.6,43.6,76.9,14.9,104.2-12.4C981,928.3,1011.8,893,968.2,849.4z M524.5,522c-88.9,88.7-233,88.7-321.8,0c-88.9-88.7-88.9-232.6,0-321.3c88.9-88.7,233-88.7,321.8,0C613.4,289.4,613.4,433.3,524.5,522z"
+              ></path></svg
+            ><input
+              placeholder="Search..."
+              aria-label="Search"
+              type="text"
+              class="sc-lhsSio iOkeQy search-input"
+              value=""
+            />
+          </div>
+          <div class="sc-eknHtZ ghzOpX scrollbar-container undefined">
+            <ul role="menu" class="sc-zOxLx gAPKXX">
+              <li
+                tabindex="0"
+                depth="1"
+                data-item-id="tag/Admin"
+                role="menuitem"
+                aria-label="Admin"
+                aria-expanded="false"
+                class="sc-cgHfjM ixknQI"
+              >
+                <label class="sc-fpikKz lgPGwq -depth1"
+                  ><span width="calc(100% - 38px)" title="Admin" class="sc-gWaSiO cxcra">Admin</span
+                  ><svg
+                    class="sc-dntSTA dUlzCe"
+                    version="1.1"
+                    viewBox="0 0 24 24"
+                    x="0"
+                    xmlns="http://www.w3.org/2000/svg"
+                    y="0"
+                    aria-hidden="true"
+                  >
+                    <polygon
+                      points="17.3 8.3 12 13.6 6.7 8.3 5.3 9.7 12 16.4 18.7 9.7 "
+                    ></polygon></svg
+                ></label>
+                <ul class="sc-zOxLx dQnkdy">
+                  <li
+                    tabindex="0"
+                    depth="2"
+                    data-item-id="tag/Admin/paths/~1admin~1create-user/post"
+                    role="menuitem"
+                    aria-label="Create a new user"
+                    aria-expanded="false"
+                    class="sc-cgHfjM ixknQI"
+                  >
+                    <label class="sc-fpikKz iHRgeo -depth2"
+                      ><span type="post" class="sc-jxYSNo NmQLu operation-type post">post</span
+                      ><span tabindex="0" width="calc(100% - 38px)" class="sc-gWaSiO cxcra"
+                        >Create a new user</span
+                      ></label
+                    >
+                  </li>
+                  <li
+                    tabindex="0"
+                    depth="2"
+                    data-item-id="tag/Admin/paths/~1admin~1user~1{id}/get"
+                    role="menuitem"
+                    aria-label="Get a user by ID"
+                    aria-expanded="false"
+                    class="sc-cgHfjM ixknQI"
+                  >
+                    <label class="sc-fpikKz iHRgeo -depth2"
+                      ><span type="get" class="sc-jxYSNo NmQLu operation-type get">get</span
+                      ><span tabindex="0" width="calc(100% - 38px)" class="sc-gWaSiO cxcra"
+                        >Get a user by ID</span
+                      ></label
+                    >
+                  </li>
+                  <li
+                    tabindex="0"
+                    depth="2"
+                    data-item-id="tag/Admin/paths/~1admin~1user~1{id}/delete"
+                    role="menuitem"
+                    aria-label="Delete a user by ID"
+                    aria-expanded="false"
+                    class="sc-cgHfjM ixknQI"
+                  >
+                    <label class="sc-fpikKz iHRgeo -depth2"
+                      ><span type="delete" class="sc-jxYSNo NmQLu operation-type delete">del</span
+                      ><span tabindex="0" width="calc(100% - 38px)" class="sc-gWaSiO cxcra"
+                        >Delete a user by ID</span
+                      ></label
+                    >
+                  </li>
+                  <li
+                    tabindex="0"
+                    depth="2"
+                    data-item-id="tag/Admin/paths/~1admin~1users/get"
+                    role="menuitem"
+                    aria-label="Get all users (paginated)"
+                    aria-expanded="false"
+                    class="sc-cgHfjM ixknQI"
+                  >
+                    <label class="sc-fpikKz iHRgeo -depth2"
+                      ><span type="get" class="sc-jxYSNo NmQLu operation-type get">get</span
+                      ><span tabindex="0" width="calc(100% - 38px)" class="sc-gWaSiO cxcra"
+                        >Get all users (paginated)</span
+                      ></label
+                    >
+                  </li>
+                </ul>
+              </li>
+            </ul>
+            <div class="sc-kSaXSp QuyG">
+              <a target="_blank" rel="noopener noreferrer" href="https://redocly.com/redoc/"
+                >API docs by Redocly</a
+              >
+            </div>
+          </div>
+        </div>
+        <div class="sc-jOlHRD bovaLG">
+          <div class="sc-cZnrqW crXcHD">
+            <svg
+              class=""
+              style="
+                transform: translate(2px, -4px) rotate(180deg);
+                transition: transform 0.2s ease;
+              "
+              viewBox="0 0 926.23699 573.74994"
+              version="1.1"
+              x="0px"
+              y="0px"
+              width="15"
+              height="15"
+            >
+              <g transform="translate(904.92214,-879.1482)">
+                <path
+                  d="
+          m -673.67664,1221.6502 -231.2455,-231.24803 55.6165,
+          -55.627 c 30.5891,-30.59485 56.1806,-55.627 56.8701,-55.627 0.6894,
+          0 79.8637,78.60862 175.9427,174.68583 l 174.6892,174.6858 174.6892,
+          -174.6858 c 96.079,-96.07721 175.253196,-174.68583 175.942696,
+          -174.68583 0.6895,0 26.281,25.03215 56.8701,
+          55.627 l 55.6165,55.627 -231.245496,231.24803 c -127.185,127.1864
+          -231.5279,231.248 -231.873,231.248 -0.3451,0 -104.688,
+          -104.0616 -231.873,-231.248 z
+        "
+                  fill="currentColor"
+                ></path>
+              </g></svg
+            ><svg
+              class=""
+              style="transform: translate(2px, 4px); transition: transform 0.2s ease"
+              viewBox="0 0 926.23699 573.74994"
+              version="1.1"
+              x="0px"
+              y="0px"
+              width="15"
+              height="15"
+            >
+              <g transform="translate(904.92214,-879.1482)">
+                <path
+                  d="
+          m -673.67664,1221.6502 -231.2455,-231.24803 55.6165,
+          -55.627 c 30.5891,-30.59485 56.1806,-55.627 56.8701,-55.627 0.6894,
+          0 79.8637,78.60862 175.9427,174.68583 l 174.6892,174.6858 174.6892,
+          -174.6858 c 96.079,-96.07721 175.253196,-174.68583 175.942696,
+          -174.68583 0.6895,0 26.281,25.03215 56.8701,
+          55.627 l 55.6165,55.627 -231.245496,231.24803 c -127.185,127.1864
+          -231.5279,231.248 -231.873,231.248 -0.3451,0 -104.688,
+          -104.0616 -231.873,-231.248 z
+        "
+                  fill="currentColor"
+                ></path>
+              </g>
+            </svg>
+          </div>
+        </div>
+        <div class="sc-fkYqBV buanwU api-content">
+          <div class="sc-dTvVRJ bPmFpz">
+            <div class="sc-jJLAfE gkiSyE">
+              <div class="sc-ggWZvA fqkwbU api-info">
+                <h1 class="sc-hwkwBN sc-jCWzJg wYHiz hPcPCj">
+                  Admin API<!-- -->
+                  <span>(<!-- -->1.0.0<!-- -->)</span>
+                </h1>
+                <p>Download OpenAPI specification<!-- -->:</p>
+                <div class="sc-eVqvcJ sc-fszimp kIppRw kbZred"></div>
+                <div
+                  data-role="redoc-summary"
+                  html=""
+                  class="sc-eVqvcJ sc-fszimp kIppRw kbZred"
+                ></div>
+                <div
+                  data-role="redoc-description"
+                  html="&lt;p&gt;Admin-only endpoints for user management&lt;/p&gt;
+"
+                  class="sc-eVqvcJ sc-fszimp kIppRw kbZred"
+                >
+                  <p>Admin-only endpoints for user management</p>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div id="tag/Admin" data-section-id="tag/Admin" class="sc-dTvVRJ bPmFpz">
+            <div class="sc-jJLAfE gkiSyE">
+              <div class="sc-ggWZvA fqkwbU">
+                <h2 class="sc-kNOymR iFSqkw">
+                  <a class="sc-kcLKEh fRdsOi" href="#tag/Admin" aria-label="tag/Admin"></a>Admin
+                </h2>
+              </div>
+            </div>
+            <div class="sc-ggWZvA dCzIPc">
+              <div
+                class="sc-eVqvcJ sc-fszimp kIppRw kbZred redoc-markdown"
+                html="&lt;p&gt;Admin endpoints&lt;/p&gt;
+"
+              >
+                <p>Admin endpoints</p>
+              </div>
+            </div>
+          </div>
+          <div
+            id="tag/Admin/paths/~1admin~1create-user/post"
+            data-section-id="tag/Admin/paths/~1admin~1create-user/post"
+            class="sc-dTvVRJ gHrCVQ"
+          >
+            <div class="sc-jJLAfE gkiSyE">
+              <div class="sc-ggWZvA fqkwbU">
+                <h2 class="sc-kNOymR iFSqkw">
+                  <a
+                    class="sc-kcLKEh fRdsOi"
+                    href="#tag/Admin/paths/~1admin~1create-user/post"
+                    aria-label="tag/Admin/paths/~1admin~1create-user/post"
+                  ></a
+                  >Create a new user<!-- -->
+                </h2>
+                <div class="sc-ikkVnJ deUlC">
+                  <div class="sc-hWgKua dPSGXF">
+                    <h5 class="sc-eqYatC sc-gFqXPY czjApA jCoZLr">Authorizations:</h5>
+                    <svg
+                      class="sc-dntSTA FtowP"
+                      version="1.1"
+                      viewBox="0 0 24 24"
+                      x="0"
+                      xmlns="http://www.w3.org/2000/svg"
+                      y="0"
+                      aria-hidden="true"
+                    >
+                      <polygon
+                        points="17.3 8.3 12 13.6 6.7 8.3 5.3 9.7 12 16.4 18.7 9.7 "
+                      ></polygon>
+                    </svg>
+                  </div>
+                  <div class="sc-jBaHRL fUkQtw">
+                    <span class="sc-iVnIWt gRXavu"
+                      ><span class="sc-hqtLyI hRtRoN"><i>bearerAuth</i></span></span
+                    >
+                  </div>
+                </div>
+                <h5 class="sc-eqYatC czjApA">
+                  Request Body schema: <span class="sc-dNFkOE cFlAeY">application/json</span>
+                  <div class="sc-bEjUoa sc-iIvHqT sc-eTCgfj lhyyLL crXmiY foplsk">required</div>
+                </h5>
+                <div html="" class="sc-eVqvcJ sc-fszimp kIppRw kbZred"></div>
+                <table class="sc-eqNDNG icJLQx">
+                  <tbody>
+                    <tr class="">
+                      <td kind="field" title="name" class="sc-kCuUfV sc-fbQrwq gdmNWp dFOJWJ">
+                        <span class="sc-hwddKA cteAyA"></span
+                        ><span class="property-name">name</span>
+                        <div class="sc-bEjUoa sc-iIvHqT lhyyLL crXmiY">required</div>
+                      </td>
+                      <td class="sc-gGKoUb ixGaBD">
+                        <div>
+                          <div>
+                            <span class="sc-bEjUoa sc-boKDdR lhyyLL jYezsP"></span
+                            ><span class="sc-bEjUoa sc-fOOuSg lhyyLL dbKJYq">string</span>
+                          </div>
+                          <div><div html="" class="sc-eVqvcJ sc-fszimp kIppRw drqpJr"></div></div>
+                        </div>
+                      </td>
+                    </tr>
+                    <tr class="">
+                      <td kind="field" title="email" class="sc-kCuUfV sc-fbQrwq gdmNWp dFOJWJ">
+                        <span class="sc-hwddKA cteAyA"></span
+                        ><span class="property-name">email</span>
+                        <div class="sc-bEjUoa sc-iIvHqT lhyyLL crXmiY">required</div>
+                      </td>
+                      <td class="sc-gGKoUb ixGaBD">
+                        <div>
+                          <div>
+                            <span class="sc-bEjUoa sc-boKDdR lhyyLL jYezsP"></span
+                            ><span class="sc-bEjUoa sc-fOOuSg lhyyLL dbKJYq">string</span
+                            ><span class="sc-bEjUoa sc-fOOuSg lhyyLL dbKJYq">
+                              <!-- -->&lt;<!-- -->email<!-- -->&gt;<!-- -->
+                            </span>
+                          </div>
+                          <div><div html="" class="sc-eVqvcJ sc-fszimp kIppRw drqpJr"></div></div>
+                        </div>
+                      </td>
+                    </tr>
+                    <tr class="last">
+                      <td kind="field" title="role" class="sc-kCuUfV sc-fbQrwq gdmNWp dFOJWJ">
+                        <span class="sc-hwddKA cteAyA"></span
+                        ><span class="property-name">role</span>
+                        <div class="sc-bEjUoa sc-iIvHqT lhyyLL crXmiY">required</div>
+                      </td>
+                      <td class="sc-gGKoUb ixGaBD">
+                        <div>
+                          <div>
+                            <span class="sc-bEjUoa sc-boKDdR lhyyLL jYezsP"></span
+                            ><span class="sc-bEjUoa sc-fOOuSg lhyyLL dbKJYq">string</span>
+                          </div>
+                          <div>
+                            <span class="sc-bEjUoa lhyyLL"> <!-- -->Enum<!-- -->:</span>
+                            <span class="sc-bEjUoa sc-dTWiOz lhyyLL kMQdIk">&quot;USER&quot;</span>
+                            <span class="sc-bEjUoa sc-dTWiOz lhyyLL kMQdIk">&quot;ADMIN&quot;</span>
+                          </div>
+                          <div><div html="" class="sc-eVqvcJ sc-fszimp kIppRw drqpJr"></div></div>
+                        </div>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+                <div>
+                  <h3 class="sc-gDzyrw kjrVcG">Responses</h3>
+                  <div>
+                    <button class="sc-jIDBmd lkmdtA">
+                      <svg
+                        class="sc-dntSTA cGxVlA"
+                        version="1.1"
+                        viewBox="0 0 24 24"
+                        x="0"
+                        xmlns="http://www.w3.org/2000/svg"
+                        y="0"
+                        aria-hidden="true"
+                      >
+                        <polygon
+                          points="17.3 8.3 12 13.6 6.7 8.3 5.3 9.7 12 16.4 18.7 9.7 "
+                        ></polygon></svg
+                      ><strong class="sc-eJvlPh fBhAXU">201<!-- --> </strong>
+                      <div
+                        html="&lt;p&gt;User created&lt;/p&gt;
+"
+                        class="sc-eVqvcJ sc-fszimp sc-etsjJW kIppRw jnwENr ljKHqG"
+                      >
+                        <p>User created</p>
+                      </div>
+                    </button>
+                  </div>
+                  <div>
+                    <button class="sc-jIDBmd ifAHvq">
+                      <svg
+                        class="sc-dntSTA jKYZgc"
+                        version="1.1"
+                        viewBox="0 0 24 24"
+                        x="0"
+                        xmlns="http://www.w3.org/2000/svg"
+                        y="0"
+                        aria-hidden="true"
+                      >
+                        <polygon
+                          points="17.3 8.3 12 13.6 6.7 8.3 5.3 9.7 12 16.4 18.7 9.7 "
+                        ></polygon></svg
+                      ><strong class="sc-eJvlPh fBhAXU">400<!-- --> </strong>
+                      <div
+                        html="&lt;p&gt;Validation error&lt;/p&gt;
+"
+                        class="sc-eVqvcJ sc-fszimp sc-etsjJW kIppRw jnwENr ljKHqG"
+                      >
+                        <p>Validation error</p>
+                      </div>
+                    </button>
+                  </div>
+                  <div>
+                    <button class="sc-jIDBmd kQCDrg" disabled="">
+                      <strong class="sc-eJvlPh fBhAXU">401<!-- --> </strong>
+                      <div
+                        html="&lt;p&gt;Unauthorized&lt;/p&gt;
+"
+                        class="sc-eVqvcJ sc-fszimp sc-etsjJW kIppRw jnwENr ljKHqG"
+                      >
+                        <p>Unauthorized</p>
+                      </div>
+                    </button>
+                  </div>
+                  <div>
+                    <button class="sc-jIDBmd kQCDrg" disabled="">
+                      <strong class="sc-eJvlPh fBhAXU">403<!-- --> </strong>
+                      <div
+                        html="&lt;p&gt;Forbidden&lt;/p&gt;
+"
+                        class="sc-eVqvcJ sc-fszimp sc-etsjJW kIppRw jnwENr ljKHqG"
+                      >
+                        <p>Forbidden</p>
+                      </div>
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <div class="sc-jwTyAe sc-hjsuWn bDYKKx FFPsr">
+                <div class="sc-eZSpzM jjnszm">
+                  <button class="sc-buTqWO iPCVMX">
+                    <span type="post" class="sc-fQLpxn kwcmyC http-verb post">post</span
+                    ><span class="sc-jvKoal kZcHWP">/admin/create-user</span
+                    ><svg
+                      class="sc-dntSTA iuNpUs"
+                      style="margin-right: -25px"
+                      version="1.1"
+                      viewBox="0 0 24 24"
+                      x="0"
+                      xmlns="http://www.w3.org/2000/svg"
+                      y="0"
+                      aria-hidden="true"
+                    >
+                      <polygon
+                        points="17.3 8.3 12 13.6 6.7 8.3 5.3 9.7 12 16.4 18.7 9.7 "
+                      ></polygon>
+                    </svg>
+                  </button>
+                  <div aria-hidden="true" class="sc-ecJghI ga-DQLq">
+                    <div class="sc-iyBeIh icOxsG">
+                      <div html="" class="sc-eVqvcJ sc-fszimp kIppRw drqpJr"></div>
+                      <div tabindex="0" role="button">
+                        <div class="sc-xKhEK okJpy">
+                          <span>https://your-api-domain.com</span>/admin/create-user
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <h3 class="sc-lgpSej drJHMo"><!-- -->Request samples<!-- --></h3>
+                  <div class="sc-cOpnSz fyxuKi" data-rttabs="true">
+                    <ul class="react-tabs__tab-list" role="tablist">
+                      <li
+                        class="react-tabs__tab react-tabs__tab--selected"
+                        role="tab"
+                        id="tab«R996q»0"
+                        aria-selected="true"
+                        aria-disabled="false"
+                        aria-controls="panel«R996q»0"
+                        tabindex="0"
+                        data-rttab="true"
+                      >
+                        Payload
+                      </li>
+                    </ul>
+                    <div
+                      class="react-tabs__tab-panel react-tabs__tab-panel--selected"
+                      role="tabpanel"
+                      id="panel«R996q»0"
+                      aria-labelledby="tab«R996q»0"
+                    >
+                      <div>
+                        <div class="sc-bSFBcf iLdyBp">
+                          <span class="sc-gahYZc cXitJ">Content type</span>
+                          <div class="sc-bAehkN iNRAJK">application/json</div>
+                        </div>
+                        <div class="sc-blIAwI eKKwxo">
+                          <div class="sc-dClGHI fdRrNy">
+                            <div class="sc-bbbBoY bBWkcI">
+                              <button><div class="sc-fYmhhH iNCOCX">Copy</div></button>
+                            </div>
+                            <div tabindex="0" class="sc-eVqvcJ kIppRw sc-fhfEft dFvLDb">
+                              <div class="redoc-json">
+                                <code
+                                  ><button class="collapser" aria-label="collapse"></button
+                                  ><span class="token punctuation">{</span
+                                  ><span class="ellipsis"></span>
+                                  <ul class="obj collapsible">
+                                    <li>
+                                      <div class="hoverable">
+                                        <span class="property token string">"name"</span>:
+                                        <span class="token string">&quot;string&quot;</span
+                                        ><span class="token punctuation">,</span>
+                                      </div>
+                                    </li>
+                                    <li>
+                                      <div class="hoverable">
+                                        <span class="property token string">"email"</span>:
+                                        <span class="token string"
+                                          >&quot;user@example.com&quot;</span
+                                        ><span class="token punctuation">,</span>
+                                      </div>
+                                    </li>
+                                    <li>
+                                      <div class="hoverable">
+                                        <span class="property token string">"role"</span>:
+                                        <span class="token string">&quot;USER&quot;</span>
+                                      </div>
+                                    </li>
+                                  </ul>
+                                  <span class="token punctuation">}</span></code
+                                >
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <h3 class="sc-lgpSej drJHMo"><!-- -->Response samples<!-- --></h3>
+                  <div class="sc-cOpnSz fyxuKi" data-rttabs="true">
+                    <ul class="react-tabs__tab-list" role="tablist">
+                      <li
+                        class="tab-success react-tabs__tab--selected"
+                        role="tab"
+                        id="tab«R9p6q»0"
+                        aria-selected="true"
+                        aria-disabled="false"
+                        aria-controls="panel«R9p6q»0"
+                        tabindex="0"
+                        data-rttab="true"
+                      >
+                        201
+                      </li>
+                      <li
+                        class="tab-error"
+                        role="tab"
+                        id="tab«R9p6q»1"
+                        aria-selected="false"
+                        aria-disabled="false"
+                        aria-controls="panel«R9p6q»1"
+                        data-rttab="true"
+                      >
+                        400
+                      </li>
+                    </ul>
+                    <div
+                      class="react-tabs__tab-panel react-tabs__tab-panel--selected"
+                      role="tabpanel"
+                      id="panel«R9p6q»0"
+                      aria-labelledby="tab«R9p6q»0"
+                    >
+                      <div>
+                        <div class="sc-bSFBcf iLdyBp">
+                          <span class="sc-gahYZc cXitJ">Content type</span>
+                          <div class="sc-bAehkN iNRAJK">application/json</div>
+                        </div>
+                        <div class="sc-blIAwI eKKwxo">
+                          <div class="sc-dClGHI fdRrNy">
+                            <div class="sc-bbbBoY bBWkcI">
+                              <button><div class="sc-fYmhhH iNCOCX">Copy</div></button
+                              ><button>Expand all</button><button>Collapse all</button>
+                            </div>
+                            <div tabindex="0" class="sc-eVqvcJ kIppRw sc-fhfEft dFvLDb">
+                              <div class="redoc-json">
+                                <code
+                                  ><button class="collapser" aria-label="collapse"></button
+                                  ><span class="token punctuation">{</span
+                                  ><span class="ellipsis"></span>
+                                  <ul class="obj collapsible">
+                                    <li>
+                                      <div class="hoverable">
+                                        <span class="property token string">"success"</span>:
+                                        <span class="token boolean">true</span
+                                        ><span class="token punctuation">,</span>
+                                      </div>
+                                    </li>
+                                    <li>
+                                      <div class="hoverable">
+                                        <span class="property token string">"data"</span>:
+                                        <button class="collapser" aria-label="collapse"></button
+                                        ><span class="token punctuation">{</span
+                                        ><span class="ellipsis"></span>
+                                        <ul class="obj collapsible">
+                                          <li>
+                                            <div class="hoverable collapsed">
+                                              <span class="property token string">"id"</span>:
+                                              <span class="token string">&quot;string&quot;</span
+                                              ><span class="token punctuation">,</span>
+                                            </div>
+                                          </li>
+                                          <li>
+                                            <div class="hoverable collapsed">
+                                              <span class="property token string">"name"</span>:
+                                              <span class="token string">&quot;string&quot;</span
+                                              ><span class="token punctuation">,</span>
+                                            </div>
+                                          </li>
+                                          <li>
+                                            <div class="hoverable collapsed">
+                                              <span class="property token string">"email"</span>:
+                                              <span class="token string"
+                                                >&quot;user@example.com&quot;</span
+                                              >
+                                            </div>
+                                          </li>
+                                        </ul>
+                                        <span class="token punctuation">}</span>
+                                      </div>
+                                    </li>
+                                  </ul>
+                                  <span class="token punctuation">}</span></code
+                                >
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="react-tabs__tab-panel"
+                      role="tabpanel"
+                      id="panel«R9p6q»1"
+                      aria-labelledby="tab«R9p6q»1"
+                    ></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            id="tag/Admin/paths/~1admin~1user~1{id}/get"
+            data-section-id="tag/Admin/paths/~1admin~1user~1{id}/get"
+            class="sc-dTvVRJ gHrCVQ"
+          >
+            <div class="sc-jJLAfE gkiSyE">
+              <div class="sc-ggWZvA fqkwbU">
+                <h2 class="sc-kNOymR iFSqkw">
+                  <a
+                    class="sc-kcLKEh fRdsOi"
+                    href="#tag/Admin/paths/~1admin~1user~1{id}/get"
+                    aria-label="tag/Admin/paths/~1admin~1user~1{id}/get"
+                  ></a
+                  >Get a user by ID<!-- -->
+                </h2>
+                <div class="sc-ikkVnJ deUlC">
+                  <div class="sc-hWgKua dPSGXF">
+                    <h5 class="sc-eqYatC sc-gFqXPY czjApA jCoZLr">Authorizations:</h5>
+                    <svg
+                      class="sc-dntSTA FtowP"
+                      version="1.1"
+                      viewBox="0 0 24 24"
+                      x="0"
+                      xmlns="http://www.w3.org/2000/svg"
+                      y="0"
+                      aria-hidden="true"
+                    >
+                      <polygon
+                        points="17.3 8.3 12 13.6 6.7 8.3 5.3 9.7 12 16.4 18.7 9.7 "
+                      ></polygon>
+                    </svg>
+                  </div>
+                  <div class="sc-jBaHRL fUkQtw">
+                    <span class="sc-iVnIWt gRXavu"
+                      ><span class="sc-hqtLyI hRtRoN"><i>bearerAuth</i></span></span
+                    >
+                  </div>
+                </div>
+                <div>
+                  <h5 class="sc-eqYatC czjApA">
+                    path<!-- -->
+                    Parameters
+                  </h5>
+                  <table class="sc-eqNDNG icJLQx">
+                    <tbody>
+                      <tr class="last">
+                        <td kind="field" title="id" class="sc-kCuUfV sc-fbQrwq gdmNWp dFOJWJ">
+                          <span class="sc-hwddKA cteAyA"></span
+                          ><span class="property-name">id</span>
+                          <div class="sc-bEjUoa sc-iIvHqT lhyyLL crXmiY">required</div>
+                        </td>
+                        <td class="sc-gGKoUb ixGaBD">
+                          <div>
+                            <div>
+                              <span class="sc-bEjUoa sc-boKDdR lhyyLL jYezsP"></span
+                              ><span class="sc-bEjUoa sc-fOOuSg lhyyLL dbKJYq">string</span>
+                            </div>
+                            <div><div html="" class="sc-eVqvcJ sc-fszimp kIppRw drqpJr"></div></div>
+                          </div>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+                <div>
+                  <h3 class="sc-gDzyrw kjrVcG">Responses</h3>
+                  <div>
+                    <button class="sc-jIDBmd lkmdtA">
+                      <svg
+                        class="sc-dntSTA cGxVlA"
+                        version="1.1"
+                        viewBox="0 0 24 24"
+                        x="0"
+                        xmlns="http://www.w3.org/2000/svg"
+                        y="0"
+                        aria-hidden="true"
+                      >
+                        <polygon
+                          points="17.3 8.3 12 13.6 6.7 8.3 5.3 9.7 12 16.4 18.7 9.7 "
+                        ></polygon></svg
+                      ><strong class="sc-eJvlPh fBhAXU">200<!-- --> </strong>
+                      <div
+                        html="&lt;p&gt;User found&lt;/p&gt;
+"
+                        class="sc-eVqvcJ sc-fszimp sc-etsjJW kIppRw jnwENr ljKHqG"
+                      >
+                        <p>User found</p>
+                      </div>
+                    </button>
+                  </div>
+                  <div>
+                    <button class="sc-jIDBmd kQCDrg" disabled="">
+                      <strong class="sc-eJvlPh fBhAXU">401<!-- --> </strong>
+                      <div
+                        html="&lt;p&gt;Unauthorized&lt;/p&gt;
+"
+                        class="sc-eVqvcJ sc-fszimp sc-etsjJW kIppRw jnwENr ljKHqG"
+                      >
+                        <p>Unauthorized</p>
+                      </div>
+                    </button>
+                  </div>
+                  <div>
+                    <button class="sc-jIDBmd kQCDrg" disabled="">
+                      <strong class="sc-eJvlPh fBhAXU">403<!-- --> </strong>
+                      <div
+                        html="&lt;p&gt;Forbidden&lt;/p&gt;
+"
+                        class="sc-eVqvcJ sc-fszimp sc-etsjJW kIppRw jnwENr ljKHqG"
+                      >
+                        <p>Forbidden</p>
+                      </div>
+                    </button>
+                  </div>
+                  <div>
+                    <button class="sc-jIDBmd ifAHvq">
+                      <svg
+                        class="sc-dntSTA jKYZgc"
+                        version="1.1"
+                        viewBox="0 0 24 24"
+                        x="0"
+                        xmlns="http://www.w3.org/2000/svg"
+                        y="0"
+                        aria-hidden="true"
+                      >
+                        <polygon
+                          points="17.3 8.3 12 13.6 6.7 8.3 5.3 9.7 12 16.4 18.7 9.7 "
+                        ></polygon></svg
+                      ><strong class="sc-eJvlPh fBhAXU">404<!-- --> </strong>
+                      <div
+                        html="&lt;p&gt;User not found&lt;/p&gt;
+"
+                        class="sc-eVqvcJ sc-fszimp sc-etsjJW kIppRw jnwENr ljKHqG"
+                      >
+                        <p>User not found</p>
+                      </div>
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <div class="sc-jwTyAe sc-hjsuWn bDYKKx FFPsr">
+                <div class="sc-eZSpzM jjnszm">
+                  <button class="sc-buTqWO iPCVMX">
+                    <span type="get" class="sc-fQLpxn dynMBc http-verb get">get</span
+                    ><span class="sc-jvKoal kZcHWP">/admin/user/{id}</span
+                    ><svg
+                      class="sc-dntSTA iuNpUs"
+                      style="margin-right: -25px"
+                      version="1.1"
+                      viewBox="0 0 24 24"
+                      x="0"
+                      xmlns="http://www.w3.org/2000/svg"
+                      y="0"
+                      aria-hidden="true"
+                    >
+                      <polygon
+                        points="17.3 8.3 12 13.6 6.7 8.3 5.3 9.7 12 16.4 18.7 9.7 "
+                      ></polygon>
+                    </svg>
+                  </button>
+                  <div aria-hidden="true" class="sc-ecJghI ga-DQLq">
+                    <div class="sc-iyBeIh icOxsG">
+                      <div html="" class="sc-eVqvcJ sc-fszimp kIppRw drqpJr"></div>
+                      <div tabindex="0" role="button">
+                        <div class="sc-xKhEK okJpy">
+                          <span>https://your-api-domain.com</span>/admin/user/{id}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <h3 class="sc-lgpSej drJHMo"><!-- -->Response samples<!-- --></h3>
+                  <div class="sc-cOpnSz fyxuKi" data-rttabs="true">
+                    <ul class="react-tabs__tab-list" role="tablist">
+                      <li
+                        class="tab-success react-tabs__tab--selected"
+                        role="tab"
+                        id="tab«R9paq»0"
+                        aria-selected="true"
+                        aria-disabled="false"
+                        aria-controls="panel«R9paq»0"
+                        tabindex="0"
+                        data-rttab="true"
+                      >
+                        200
+                      </li>
+                      <li
+                        class="tab-error"
+                        role="tab"
+                        id="tab«R9paq»1"
+                        aria-selected="false"
+                        aria-disabled="false"
+                        aria-controls="panel«R9paq»1"
+                        data-rttab="true"
+                      >
+                        404
+                      </li>
+                    </ul>
+                    <div
+                      class="react-tabs__tab-panel react-tabs__tab-panel--selected"
+                      role="tabpanel"
+                      id="panel«R9paq»0"
+                      aria-labelledby="tab«R9paq»0"
+                    >
+                      <div>
+                        <div class="sc-bSFBcf iLdyBp">
+                          <span class="sc-gahYZc cXitJ">Content type</span>
+                          <div class="sc-bAehkN iNRAJK">application/json</div>
+                        </div>
+                        <div class="sc-blIAwI eKKwxo">
+                          <div class="sc-dClGHI fdRrNy">
+                            <div class="sc-bbbBoY bBWkcI">
+                              <button><div class="sc-fYmhhH iNCOCX">Copy</div></button
+                              ><button>Expand all</button><button>Collapse all</button>
+                            </div>
+                            <div tabindex="0" class="sc-eVqvcJ kIppRw sc-fhfEft dFvLDb">
+                              <div class="redoc-json">
+                                <code
+                                  ><button class="collapser" aria-label="collapse"></button
+                                  ><span class="token punctuation">{</span
+                                  ><span class="ellipsis"></span>
+                                  <ul class="obj collapsible">
+                                    <li>
+                                      <div class="hoverable">
+                                        <span class="property token string">"success"</span>:
+                                        <span class="token boolean">true</span
+                                        ><span class="token punctuation">,</span>
+                                      </div>
+                                    </li>
+                                    <li>
+                                      <div class="hoverable">
+                                        <span class="property token string">"data"</span>:
+                                        <button class="collapser" aria-label="collapse"></button
+                                        ><span class="token punctuation">{</span
+                                        ><span class="ellipsis"></span>
+                                        <ul class="obj collapsible">
+                                          <li>
+                                            <div class="hoverable collapsed">
+                                              <span class="property token string">"id"</span>:
+                                              <span class="token string">&quot;string&quot;</span
+                                              ><span class="token punctuation">,</span>
+                                            </div>
+                                          </li>
+                                          <li>
+                                            <div class="hoverable collapsed">
+                                              <span class="property token string">"name"</span>:
+                                              <span class="token string">&quot;string&quot;</span
+                                              ><span class="token punctuation">,</span>
+                                            </div>
+                                          </li>
+                                          <li>
+                                            <div class="hoverable collapsed">
+                                              <span class="property token string">"email"</span>:
+                                              <span class="token string"
+                                                >&quot;user@example.com&quot;</span
+                                              >
+                                            </div>
+                                          </li>
+                                        </ul>
+                                        <span class="token punctuation">}</span>
+                                      </div>
+                                    </li>
+                                  </ul>
+                                  <span class="token punctuation">}</span></code
+                                >
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="react-tabs__tab-panel"
+                      role="tabpanel"
+                      id="panel«R9paq»1"
+                      aria-labelledby="tab«R9paq»1"
+                    ></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            id="tag/Admin/paths/~1admin~1user~1{id}/delete"
+            data-section-id="tag/Admin/paths/~1admin~1user~1{id}/delete"
+            class="sc-dTvVRJ gHrCVQ"
+          >
+            <div class="sc-jJLAfE gkiSyE">
+              <div class="sc-ggWZvA fqkwbU">
+                <h2 class="sc-kNOymR iFSqkw">
+                  <a
+                    class="sc-kcLKEh fRdsOi"
+                    href="#tag/Admin/paths/~1admin~1user~1{id}/delete"
+                    aria-label="tag/Admin/paths/~1admin~1user~1{id}/delete"
+                  ></a
+                  >Delete a user by ID<!-- -->
+                </h2>
+                <div class="sc-ikkVnJ deUlC">
+                  <div class="sc-hWgKua dPSGXF">
+                    <h5 class="sc-eqYatC sc-gFqXPY czjApA jCoZLr">Authorizations:</h5>
+                    <svg
+                      class="sc-dntSTA FtowP"
+                      version="1.1"
+                      viewBox="0 0 24 24"
+                      x="0"
+                      xmlns="http://www.w3.org/2000/svg"
+                      y="0"
+                      aria-hidden="true"
+                    >
+                      <polygon
+                        points="17.3 8.3 12 13.6 6.7 8.3 5.3 9.7 12 16.4 18.7 9.7 "
+                      ></polygon>
+                    </svg>
+                  </div>
+                  <div class="sc-jBaHRL fUkQtw">
+                    <span class="sc-iVnIWt gRXavu"
+                      ><span class="sc-hqtLyI hRtRoN"><i>bearerAuth</i></span></span
+                    >
+                  </div>
+                </div>
+                <div>
+                  <h5 class="sc-eqYatC czjApA">
+                    path<!-- -->
+                    Parameters
+                  </h5>
+                  <table class="sc-eqNDNG icJLQx">
+                    <tbody>
+                      <tr class="last">
+                        <td kind="field" title="id" class="sc-kCuUfV sc-fbQrwq gdmNWp dFOJWJ">
+                          <span class="sc-hwddKA cteAyA"></span
+                          ><span class="property-name">id</span>
+                          <div class="sc-bEjUoa sc-iIvHqT lhyyLL crXmiY">required</div>
+                        </td>
+                        <td class="sc-gGKoUb ixGaBD">
+                          <div>
+                            <div>
+                              <span class="sc-bEjUoa sc-boKDdR lhyyLL jYezsP"></span
+                              ><span class="sc-bEjUoa sc-fOOuSg lhyyLL dbKJYq">string</span>
+                            </div>
+                            <div><div html="" class="sc-eVqvcJ sc-fszimp kIppRw drqpJr"></div></div>
+                          </div>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+                <div>
+                  <h3 class="sc-gDzyrw kjrVcG">Responses</h3>
+                  <div>
+                    <button class="sc-jIDBmd lkmdtA">
+                      <svg
+                        class="sc-dntSTA cGxVlA"
+                        version="1.1"
+                        viewBox="0 0 24 24"
+                        x="0"
+                        xmlns="http://www.w3.org/2000/svg"
+                        y="0"
+                        aria-hidden="true"
+                      >
+                        <polygon
+                          points="17.3 8.3 12 13.6 6.7 8.3 5.3 9.7 12 16.4 18.7 9.7 "
+                        ></polygon></svg
+                      ><strong class="sc-eJvlPh fBhAXU">200<!-- --> </strong>
+                      <div
+                        html="&lt;p&gt;User deleted&lt;/p&gt;
+"
+                        class="sc-eVqvcJ sc-fszimp sc-etsjJW kIppRw jnwENr ljKHqG"
+                      >
+                        <p>User deleted</p>
+                      </div>
+                    </button>
+                  </div>
+                  <div>
+                    <button class="sc-jIDBmd kQCDrg" disabled="">
+                      <strong class="sc-eJvlPh fBhAXU">401<!-- --> </strong>
+                      <div
+                        html="&lt;p&gt;Unauthorized&lt;/p&gt;
+"
+                        class="sc-eVqvcJ sc-fszimp sc-etsjJW kIppRw jnwENr ljKHqG"
+                      >
+                        <p>Unauthorized</p>
+                      </div>
+                    </button>
+                  </div>
+                  <div>
+                    <button class="sc-jIDBmd kQCDrg" disabled="">
+                      <strong class="sc-eJvlPh fBhAXU">403<!-- --> </strong>
+                      <div
+                        html="&lt;p&gt;Forbidden&lt;/p&gt;
+"
+                        class="sc-eVqvcJ sc-fszimp sc-etsjJW kIppRw jnwENr ljKHqG"
+                      >
+                        <p>Forbidden</p>
+                      </div>
+                    </button>
+                  </div>
+                  <div>
+                    <button class="sc-jIDBmd ifAHvq">
+                      <svg
+                        class="sc-dntSTA jKYZgc"
+                        version="1.1"
+                        viewBox="0 0 24 24"
+                        x="0"
+                        xmlns="http://www.w3.org/2000/svg"
+                        y="0"
+                        aria-hidden="true"
+                      >
+                        <polygon
+                          points="17.3 8.3 12 13.6 6.7 8.3 5.3 9.7 12 16.4 18.7 9.7 "
+                        ></polygon></svg
+                      ><strong class="sc-eJvlPh fBhAXU">404<!-- --> </strong>
+                      <div
+                        html="&lt;p&gt;User not found&lt;/p&gt;
+"
+                        class="sc-eVqvcJ sc-fszimp sc-etsjJW kIppRw jnwENr ljKHqG"
+                      >
+                        <p>User not found</p>
+                      </div>
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <div class="sc-jwTyAe sc-hjsuWn bDYKKx FFPsr">
+                <div class="sc-eZSpzM jjnszm">
+                  <button class="sc-buTqWO iPCVMX">
+                    <span type="delete" class="sc-fQLpxn gKcHYQ http-verb delete">delete</span
+                    ><span class="sc-jvKoal kZcHWP">/admin/user/{id}</span
+                    ><svg
+                      class="sc-dntSTA iuNpUs"
+                      style="margin-right: -25px"
+                      version="1.1"
+                      viewBox="0 0 24 24"
+                      x="0"
+                      xmlns="http://www.w3.org/2000/svg"
+                      y="0"
+                      aria-hidden="true"
+                    >
+                      <polygon
+                        points="17.3 8.3 12 13.6 6.7 8.3 5.3 9.7 12 16.4 18.7 9.7 "
+                      ></polygon>
+                    </svg>
+                  </button>
+                  <div aria-hidden="true" class="sc-ecJghI ga-DQLq">
+                    <div class="sc-iyBeIh icOxsG">
+                      <div html="" class="sc-eVqvcJ sc-fszimp kIppRw drqpJr"></div>
+                      <div tabindex="0" role="button">
+                        <div class="sc-xKhEK okJpy">
+                          <span>https://your-api-domain.com</span>/admin/user/{id}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <h3 class="sc-lgpSej drJHMo"><!-- -->Response samples<!-- --></h3>
+                  <div class="sc-cOpnSz fyxuKi" data-rttabs="true">
+                    <ul class="react-tabs__tab-list" role="tablist">
+                      <li
+                        class="tab-success react-tabs__tab--selected"
+                        role="tab"
+                        id="tab«R9peq»0"
+                        aria-selected="true"
+                        aria-disabled="false"
+                        aria-controls="panel«R9peq»0"
+                        tabindex="0"
+                        data-rttab="true"
+                      >
+                        200
+                      </li>
+                      <li
+                        class="tab-error"
+                        role="tab"
+                        id="tab«R9peq»1"
+                        aria-selected="false"
+                        aria-disabled="false"
+                        aria-controls="panel«R9peq»1"
+                        data-rttab="true"
+                      >
+                        404
+                      </li>
+                    </ul>
+                    <div
+                      class="react-tabs__tab-panel react-tabs__tab-panel--selected"
+                      role="tabpanel"
+                      id="panel«R9peq»0"
+                      aria-labelledby="tab«R9peq»0"
+                    >
+                      <div>
+                        <div class="sc-bSFBcf iLdyBp">
+                          <span class="sc-gahYZc cXitJ">Content type</span>
+                          <div class="sc-bAehkN iNRAJK">application/json</div>
+                        </div>
+                        <div class="sc-blIAwI eKKwxo">
+                          <div class="sc-dClGHI fdRrNy">
+                            <div class="sc-bbbBoY bBWkcI">
+                              <button><div class="sc-fYmhhH iNCOCX">Copy</div></button>
+                            </div>
+                            <div tabindex="0" class="sc-eVqvcJ kIppRw sc-fhfEft dFvLDb">
+                              <div class="redoc-json">
+                                <code
+                                  ><button class="collapser" aria-label="collapse"></button
+                                  ><span class="token punctuation">{</span
+                                  ><span class="ellipsis"></span>
+                                  <ul class="obj collapsible">
+                                    <li>
+                                      <div class="hoverable">
+                                        <span class="property token string">"success"</span>:
+                                        <span class="token boolean">true</span
+                                        ><span class="token punctuation">,</span>
+                                      </div>
+                                    </li>
+                                    <li>
+                                      <div class="hoverable">
+                                        <span class="property token string">"data"</span>:
+                                        <span class="token keyword">null</span>
+                                      </div>
+                                    </li>
+                                  </ul>
+                                  <span class="token punctuation">}</span></code
+                                >
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="react-tabs__tab-panel"
+                      role="tabpanel"
+                      id="panel«R9peq»1"
+                      aria-labelledby="tab«R9peq»1"
+                    ></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            id="tag/Admin/paths/~1admin~1users/get"
+            data-section-id="tag/Admin/paths/~1admin~1users/get"
+            class="sc-dTvVRJ gHrCVQ"
+          >
+            <div class="sc-jJLAfE gkiSyE">
+              <div class="sc-ggWZvA fqkwbU">
+                <h2 class="sc-kNOymR iFSqkw">
+                  <a
+                    class="sc-kcLKEh fRdsOi"
+                    href="#tag/Admin/paths/~1admin~1users/get"
+                    aria-label="tag/Admin/paths/~1admin~1users/get"
+                  ></a
+                  >Get all users (paginated)<!-- -->
+                </h2>
+                <div class="sc-ikkVnJ deUlC">
+                  <div class="sc-hWgKua dPSGXF">
+                    <h5 class="sc-eqYatC sc-gFqXPY czjApA jCoZLr">Authorizations:</h5>
+                    <svg
+                      class="sc-dntSTA FtowP"
+                      version="1.1"
+                      viewBox="0 0 24 24"
+                      x="0"
+                      xmlns="http://www.w3.org/2000/svg"
+                      y="0"
+                      aria-hidden="true"
+                    >
+                      <polygon
+                        points="17.3 8.3 12 13.6 6.7 8.3 5.3 9.7 12 16.4 18.7 9.7 "
+                      ></polygon>
+                    </svg>
+                  </div>
+                  <div class="sc-jBaHRL fUkQtw">
+                    <span class="sc-iVnIWt gRXavu"
+                      ><span class="sc-hqtLyI hRtRoN"><i>bearerAuth</i></span></span
+                    >
+                  </div>
+                </div>
+                <div>
+                  <h5 class="sc-eqYatC czjApA">
+                    query<!-- -->
+                    Parameters
+                  </h5>
+                  <table class="sc-eqNDNG icJLQx">
+                    <tbody>
+                      <tr class="">
+                        <td kind="field" title="limit" class="sc-kCuUfV sc-fbQrwq gdmNWp dFOJWJ">
+                          <span class="sc-hwddKA cteAyA"></span
+                          ><span class="property-name">limit</span>
+                        </td>
+                        <td class="sc-gGKoUb ixGaBD">
+                          <div>
+                            <div>
+                              <span class="sc-bEjUoa sc-boKDdR lhyyLL jYezsP"></span
+                              ><span class="sc-bEjUoa sc-fOOuSg lhyyLL dbKJYq">integer</span
+                              ><span>
+                                <span class="sc-bEjUoa sc-goiVcJ lhyyLL bDfgbe">
+                                  <!-- -->[ 1 .. 100 ]<!-- -->
+                                </span></span
+                              >
+                            </div>
+                            <div>
+                              <span class="sc-bEjUoa lhyyLL"> <!-- -->Default:<!-- --> </span>
+                              <span class="sc-bEjUoa sc-dTWiOz lhyyLL kMQdIk">20</span>
+                            </div>
+                            <div><div html="" class="sc-eVqvcJ sc-fszimp kIppRw drqpJr"></div></div>
+                          </div>
+                        </td>
+                      </tr>
+                      <tr class="last">
+                        <td kind="field" title="cursor" class="sc-kCuUfV sc-fbQrwq gdmNWp dFOJWJ">
+                          <span class="sc-hwddKA cteAyA"></span
+                          ><span class="property-name">cursor</span>
+                        </td>
+                        <td class="sc-gGKoUb ixGaBD">
+                          <div>
+                            <div>
+                              <span class="sc-bEjUoa sc-boKDdR lhyyLL jYezsP"></span
+                              ><span class="sc-bEjUoa sc-fOOuSg lhyyLL dbKJYq">string</span>
+                            </div>
+                            <div><div html="" class="sc-eVqvcJ sc-fszimp kIppRw drqpJr"></div></div>
+                          </div>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+                <div>
+                  <h3 class="sc-gDzyrw kjrVcG">Responses</h3>
+                  <div>
+                    <button class="sc-jIDBmd lkmdtA">
+                      <svg
+                        class="sc-dntSTA cGxVlA"
+                        version="1.1"
+                        viewBox="0 0 24 24"
+                        x="0"
+                        xmlns="http://www.w3.org/2000/svg"
+                        y="0"
+                        aria-hidden="true"
+                      >
+                        <polygon
+                          points="17.3 8.3 12 13.6 6.7 8.3 5.3 9.7 12 16.4 18.7 9.7 "
+                        ></polygon></svg
+                      ><strong class="sc-eJvlPh fBhAXU">200<!-- --> </strong>
+                      <div
+                        html="&lt;p&gt;List of users&lt;/p&gt;
+"
+                        class="sc-eVqvcJ sc-fszimp sc-etsjJW kIppRw jnwENr ljKHqG"
+                      >
+                        <p>List of users</p>
+                      </div>
+                    </button>
+                  </div>
+                  <div>
+                    <button class="sc-jIDBmd kQCDrg" disabled="">
+                      <strong class="sc-eJvlPh fBhAXU">401<!-- --> </strong>
+                      <div
+                        html="&lt;p&gt;Unauthorized&lt;/p&gt;
+"
+                        class="sc-eVqvcJ sc-fszimp sc-etsjJW kIppRw jnwENr ljKHqG"
+                      >
+                        <p>Unauthorized</p>
+                      </div>
+                    </button>
+                  </div>
+                  <div>
+                    <button class="sc-jIDBmd kQCDrg" disabled="">
+                      <strong class="sc-eJvlPh fBhAXU">403<!-- --> </strong>
+                      <div
+                        html="&lt;p&gt;Forbidden&lt;/p&gt;
+"
+                        class="sc-eVqvcJ sc-fszimp sc-etsjJW kIppRw jnwENr ljKHqG"
+                      >
+                        <p>Forbidden</p>
+                      </div>
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <div class="sc-jwTyAe sc-hjsuWn bDYKKx FFPsr">
+                <div class="sc-eZSpzM jjnszm">
+                  <button class="sc-buTqWO iPCVMX">
+                    <span type="get" class="sc-fQLpxn dynMBc http-verb get">get</span
+                    ><span class="sc-jvKoal kZcHWP">/admin/users</span
+                    ><svg
+                      class="sc-dntSTA iuNpUs"
+                      style="margin-right: -25px"
+                      version="1.1"
+                      viewBox="0 0 24 24"
+                      x="0"
+                      xmlns="http://www.w3.org/2000/svg"
+                      y="0"
+                      aria-hidden="true"
+                    >
+                      <polygon
+                        points="17.3 8.3 12 13.6 6.7 8.3 5.3 9.7 12 16.4 18.7 9.7 "
+                      ></polygon>
+                    </svg>
+                  </button>
+                  <div aria-hidden="true" class="sc-ecJghI ga-DQLq">
+                    <div class="sc-iyBeIh icOxsG">
+                      <div html="" class="sc-eVqvcJ sc-fszimp kIppRw drqpJr"></div>
+                      <div tabindex="0" role="button">
+                        <div class="sc-xKhEK okJpy">
+                          <span>https://your-api-domain.com</span>/admin/users
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div>
+                  <h3 class="sc-lgpSej drJHMo"><!-- -->Response samples<!-- --></h3>
+                  <div class="sc-cOpnSz fyxuKi" data-rttabs="true">
+                    <ul class="react-tabs__tab-list" role="tablist">
+                      <li
+                        class="tab-success react-tabs__tab--selected"
+                        role="tab"
+                        id="tab«R9piq»0"
+                        aria-selected="true"
+                        aria-disabled="false"
+                        aria-controls="panel«R9piq»0"
+                        tabindex="0"
+                        data-rttab="true"
+                      >
+                        200
+                      </li>
+                    </ul>
+                    <div
+                      class="react-tabs__tab-panel react-tabs__tab-panel--selected"
+                      role="tabpanel"
+                      id="panel«R9piq»0"
+                      aria-labelledby="tab«R9piq»0"
+                    >
+                      <div>
+                        <div class="sc-bSFBcf iLdyBp">
+                          <span class="sc-gahYZc cXitJ">Content type</span>
+                          <div class="sc-bAehkN iNRAJK">application/json</div>
+                        </div>
+                        <div class="sc-blIAwI eKKwxo">
+                          <div class="sc-dClGHI fdRrNy">
+                            <div class="sc-bbbBoY bBWkcI">
+                              <button><div class="sc-fYmhhH iNCOCX">Copy</div></button
+                              ><button>Expand all</button><button>Collapse all</button>
+                            </div>
+                            <div tabindex="0" class="sc-eVqvcJ kIppRw sc-fhfEft dFvLDb">
+                              <div class="redoc-json">
+                                <code
+                                  ><button class="collapser" aria-label="collapse"></button
+                                  ><span class="token punctuation">{</span
+                                  ><span class="ellipsis"></span>
+                                  <ul class="obj collapsible">
+                                    <li>
+                                      <div class="hoverable">
+                                        <span class="property token string">"success"</span>:
+                                        <span class="token boolean">true</span
+                                        ><span class="token punctuation">,</span>
+                                      </div>
+                                    </li>
+                                    <li>
+                                      <div class="hoverable">
+                                        <span class="property token string">"data"</span>:
+                                        <button class="collapser" aria-label="collapse"></button
+                                        ><span class="token punctuation">{</span
+                                        ><span class="ellipsis"></span>
+                                        <ul class="obj collapsible">
+                                          <li>
+                                            <div class="hoverable collapsed">
+                                              <span class="property token string">"users"</span>:
+                                              <button class="collapser" aria-label="expand"></button
+                                              ><span class="token punctuation">[</span
+                                              ><span class="ellipsis"></span>
+                                              <ul class="array collapsible">
+                                                <li>
+                                                  <div class="hoverable collapsed">
+                                                    <button
+                                                      class="collapser"
+                                                      aria-label="expand"
+                                                    ></button
+                                                    ><span class="token punctuation">{</span
+                                                    ><span class="ellipsis"></span>
+                                                    <ul class="obj collapsible">
+                                                      <li>
+                                                        <div class="hoverable collapsed">
+                                                          <span class="property token string"
+                                                            >"id"</span
+                                                          >:
+                                                          <span class="token string"
+                                                            >&quot;string&quot;</span
+                                                          ><span class="token punctuation">,</span>
+                                                        </div>
+                                                      </li>
+                                                      <li>
+                                                        <div class="hoverable collapsed">
+                                                          <span class="property token string"
+                                                            >"name"</span
+                                                          >:
+                                                          <span class="token string"
+                                                            >&quot;string&quot;</span
+                                                          ><span class="token punctuation">,</span>
+                                                        </div>
+                                                      </li>
+                                                      <li>
+                                                        <div class="hoverable collapsed">
+                                                          <span class="property token string"
+                                                            >"email"</span
+                                                          >:
+                                                          <span class="token string"
+                                                            >&quot;user@example.com&quot;</span
+                                                          >
+                                                        </div>
+                                                      </li>
+                                                    </ul>
+                                                    <span class="token punctuation">}</span>
+                                                  </div>
+                                                </li>
+                                              </ul>
+                                              <span class="token punctuation">]</span
+                                              ><span class="token punctuation">,</span>
+                                            </div>
+                                          </li>
+                                          <li>
+                                            <div class="hoverable collapsed">
+                                              <span class="property token string">"nextCursor"</span
+                                              >:
+                                              <span class="token string">&quot;string&quot;</span>
+                                            </div>
+                                          </li>
+                                        </ul>
+                                        <span class="token punctuation">}</span>
+                                      </div>
+                                    </li>
+                                  </ul>
+                                  <span class="token punctuation">}</span></code
+                                >
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="sc-evkzZa iZqpqg"></div>
+      </div>
+    </div>
+    <script>
+      const __redoc_state = {
+        menu: { activeItemIdx: -1 },
+        spec: {
+          data: {
+            openapi: '3.0.3',
+            info: {
+              title: 'Admin API',
+              version: '1.0.0',
+              description: 'Admin-only endpoints for user management',
+              'x-logo': { url: 'https://your-api-domain.com/logo.png', altText: 'Admin API Logo' },
+            },
+            servers: [{ url: 'https://your-api-domain.com' }],
+            'x-redoc-config': {
+              openapi: {
+                disableSearch: true,
+                expandResponses: '200,202',
+                jsonSamplesExpandLevel: 1,
+              },
+              theme: {
+                sidebar: { backgroundColor: '#eae0cc', textColor: '#3d005b' },
+                colors: { primary: { main: '#660099' } },
+                typography: { fontSize: '14pt', headings: { fontWeight: 'bold' } },
+              },
+            },
+            tags: [{ name: 'Admin', description: 'Admin endpoints' }],
+            paths: {
+              '/admin/create-user': {
+                post: {
+                  tags: ['Admin'],
+                  summary: 'Create a new user',
+                  security: [{ bearerAuth: [] }],
+                  requestBody: {
+                    required: true,
+                    content: {
+                      'application/json': {
+                        schema: { $ref: '#/components/schemas/CreateUserRequest' },
+                      },
+                    },
+                  },
+                  responses: {
+                    201: {
+                      description: 'User created',
+                      content: {
+                        'application/json': {
+                          schema: { $ref: '#/components/schemas/ServiceResponse_PublicUser' },
+                        },
+                      },
+                    },
+                    400: {
+                      description: 'Validation error',
+                      content: {
+                        'application/json': {
+                          schema: { $ref: '#/components/schemas/ServiceError' },
+                        },
+                      },
+                    },
+                    401: { description: 'Unauthorized' },
+                    403: { description: 'Forbidden' },
+                  },
+                },
+              },
+              '/admin/user/{id}': {
+                get: {
+                  tags: ['Admin'],
+                  summary: 'Get a user by ID',
+                  security: [{ bearerAuth: [] }],
+                  parameters: [
+                    { name: 'id', in: 'path', required: true, schema: { type: 'string' } },
+                  ],
+                  responses: {
+                    200: {
+                      description: 'User found',
+                      content: {
+                        'application/json': {
+                          schema: { $ref: '#/components/schemas/ServiceResponse_PublicUser' },
+                        },
+                      },
+                    },
+                    401: { description: 'Unauthorized' },
+                    403: { description: 'Forbidden' },
+                    404: {
+                      description: 'User not found',
+                      content: {
+                        'application/json': {
+                          schema: { $ref: '#/components/schemas/ServiceError' },
+                        },
+                      },
+                    },
+                  },
+                },
+                delete: {
+                  tags: ['Admin'],
+                  summary: 'Delete a user by ID',
+                  security: [{ bearerAuth: [] }],
+                  parameters: [
+                    { name: 'id', in: 'path', required: true, schema: { type: 'string' } },
+                  ],
+                  responses: {
+                    200: {
+                      description: 'User deleted',
+                      content: {
+                        'application/json': {
+                          schema: { $ref: '#/components/schemas/ServiceResponse_Null' },
+                        },
+                      },
+                    },
+                    401: { description: 'Unauthorized' },
+                    403: { description: 'Forbidden' },
+                    404: {
+                      description: 'User not found',
+                      content: {
+                        'application/json': {
+                          schema: { $ref: '#/components/schemas/ServiceError' },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+              '/admin/users': {
+                get: {
+                  tags: ['Admin'],
+                  summary: 'Get all users (paginated)',
+                  security: [{ bearerAuth: [] }],
+                  parameters: [
+                    {
+                      name: 'limit',
+                      in: 'query',
+                      required: false,
+                      schema: { type: 'integer', default: 20, minimum: 1, maximum: 100 },
+                    },
+                    { name: 'cursor', in: 'query', required: false, schema: { type: 'string' } },
+                  ],
+                  responses: {
+                    200: {
+                      description: 'List of users',
+                      content: {
+                        'application/json': {
+                          schema: { $ref: '#/components/schemas/ServiceResponse_PublicUserArray' },
+                        },
+                      },
+                    },
+                    401: { description: 'Unauthorized' },
+                    403: { description: 'Forbidden' },
+                  },
+                },
+              },
+            },
+            components: {
+              securitySchemes: {
+                bearerAuth: { type: 'http', scheme: 'bearer', bearerFormat: 'JWT' },
+              },
+              schemas: {
+                CreateUserRequest: {
+                  type: 'object',
+                  required: ['name', 'email', 'role'],
+                  properties: {
+                    name: { type: 'string' },
+                    email: { type: 'string', format: 'email' },
+                    role: { type: 'string', enum: ['USER', 'ADMIN'] },
+                  },
+                },
+                PublicUser: {
+                  type: 'object',
+                  properties: {
+                    id: { type: 'string' },
+                    name: { type: 'string' },
+                    email: { type: 'string', format: 'email' },
+                  },
+                },
+                ServiceResponse_PublicUser: {
+                  type: 'object',
+                  properties: {
+                    success: { type: 'boolean', enum: [true] },
+                    data: { $ref: '#/components/schemas/PublicUser' },
+                  },
+                },
+                ServiceResponse_PublicUserArray: {
+                  type: 'object',
+                  properties: {
+                    success: { type: 'boolean', enum: [true] },
+                    data: {
+                      type: 'object',
+                      properties: {
+                        users: {
+                          type: 'array',
+                          items: { $ref: '#/components/schemas/PublicUser' },
+                        },
+                        nextCursor: { type: 'string', nullable: true },
+                      },
+                    },
+                  },
+                },
+                ServiceError: {
+                  type: 'object',
+                  properties: {
+                    success: { type: 'boolean', enum: [false] },
+                    error: { type: 'string' },
+                  },
+                },
+                ServiceResponse_Null: {
+                  type: 'object',
+                  properties: {
+                    success: { type: 'boolean', enum: [true] },
+                    data: { type: 'null' },
+                  },
+                },
+              },
+            },
+          },
+        },
+        searchIndex: {
+          store: [
+            'tag/Admin',
+            'tag/Admin/paths/~1admin~1create-user/post',
+            'tag/Admin/paths/~1admin~1user~1{id}/get',
+            'tag/Admin/paths/~1admin~1user~1{id}/delete',
+            'tag/Admin/paths/~1admin~1users/get',
+          ],
+          index: {
+            version: '2.3.9',
+            fields: ['title', 'description'],
+            fieldVectors: [
+              ['title/0', [0, 1.127]],
+              ['description/0', [0, 0.688, 1, 1.089]],
+              ['title/1', [2, 1.207, 3, 1.207, 4, 0.25]],
+              ['description/1', [5, 1.488]],
+              ['title/2', [4, 0.299, 6, 0.909]],
+              ['description/2', [7, 0.94]],
+              ['title/3', [4, 0.25, 6, 0.762, 8, 1.207]],
+              ['description/3', [7, 0.94]],
+              ['title/4', [4, 0.299, 9, 1.44]],
+              ['description/4', [10, 1.488]],
+            ],
+            invertedIndex: [
+              ['admin', { _index: 0, title: { 0: {} }, description: { 0: {} } }],
+              ['admin/create-us', { _index: 5, title: {}, description: { 1: {} } }],
+              ['admin/us', { _index: 10, title: {}, description: { 4: {} } }],
+              ['admin/user/{id', { _index: 7, title: {}, description: { 2: {}, 3: {} } }],
+              ['creat', { _index: 2, title: { 1: {} }, description: {} }],
+              ['delet', { _index: 8, title: { 3: {} }, description: {} }],
+              ['endpoint', { _index: 1, title: {}, description: { 0: {} } }],
+              ['id', { _index: 6, title: { 2: {}, 3: {} }, description: {} }],
+              ['new', { _index: 3, title: { 1: {} }, description: {} }],
+              ['pagin', { _index: 9, title: { 4: {} }, description: {} }],
+              ['user', { _index: 4, title: { 1: {}, 2: {}, 3: {}, 4: {} }, description: {} }],
+            ],
+            pipeline: [],
+          },
+        },
+        options: {},
+      };
+
+      var container = document.getElementById('redoc');
+      Redoc.hydrate(__redoc_state, container);
+    </script>
+  </body>
+</html>

--- a/backend/openapi/openapi.yaml
+++ b/backend/openapi/openapi.yaml
@@ -1,0 +1,231 @@
+openapi: 3.0.3
+info:
+  title: Admin API
+  version: 1.0.0
+  description: Admin-only endpoints for user management
+  x-logo:
+    url: https://your-api-domain.com/logo.png
+    altText: Admin API Logo
+
+servers:
+  - url: https://your-api-domain.com
+
+# Redoc configuration
+x-redoc-config:
+  openapi:
+    disableSearch: true
+    expandResponses: 200,202
+    jsonSamplesExpandLevel: 1
+  theme:
+    sidebar:
+      backgroundColor: '#eae0cc'
+      textColor: '#3d005b'
+    colors:
+      primary:
+        main: '#660099'
+    typography:
+      fontSize: 14pt
+      headings:
+        fontWeight: bold
+
+tags:
+  - name: Admin
+    description: Admin endpoints
+
+paths:
+  /admin/create-user:
+    post:
+      tags: [Admin]
+      summary: Create a new user
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateUserRequest'
+      responses:
+        '201':
+          description: User created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServiceResponse_PublicUser'
+        '400':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServiceError'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+
+  /admin/user/{id}:
+    get:
+      tags: [Admin]
+      summary: Get a user by ID
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: User found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServiceResponse_PublicUser'
+        '404':
+          description: User not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServiceError'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+
+    delete:
+      tags: [Admin]
+      summary: Delete a user by ID
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: User deleted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServiceResponse_Null'
+        '404':
+          description: User not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServiceError'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+
+  /admin/users:
+    get:
+      tags: [Admin]
+      summary: Get all users (paginated)
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 20
+            minimum: 1
+            maximum: 100
+        - name: cursor
+          in: query
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: List of users
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServiceResponse_PublicUserArray'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
+  schemas:
+    CreateUserRequest:
+      type: object
+      required: [name, email, role]
+      properties:
+        name:
+          type: string
+        email:
+          type: string
+          format: email
+        role:
+          type: string
+          enum: [USER, ADMIN]
+
+    PublicUser:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        email:
+          type: string
+          format: email
+
+    ServiceResponse_PublicUser:
+      type: object
+      properties:
+        success:
+          type: boolean
+          enum: [true]
+        data:
+          $ref: '#/components/schemas/PublicUser'
+
+    ServiceResponse_PublicUserArray:
+      type: object
+      properties:
+        success:
+          type: boolean
+          enum: [true]
+        data:
+          type: object
+          properties:
+            users:
+              type: array
+              items:
+                $ref: '#/components/schemas/PublicUser'
+            nextCursor:
+              type: string
+              nullable: true
+
+    ServiceError:
+      type: object
+      properties:
+        success:
+          type: boolean
+          enum: [false]
+        error:
+          type: string
+
+    ServiceResponse_Null:
+      type: object
+      properties:
+        success:
+          type: boolean
+          enum: [true]
+        data:
+          type: 'null'

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,10 +1,15 @@
+//  External packages
 import cors from 'cors';
 import 'dotenv/config';
 import express, { NextFunction, Request, Response } from 'express';
 import morgan from 'morgan';
+import path from 'node:path';
+import fs from 'node:fs';
 
+//  Config
 import corsConfig from './config/cors.js';
 
+// Routes
 import adminRoutes from './routes/admin.routes.js';
 import countryRoutes from './routes/country.routes.js';
 import parkRoutes from './routes/park.routes.js';
@@ -12,6 +17,7 @@ import subscribersRoutes from './routes/subscribers.routes.js';
 import tourRoutes from './routes/tour.routes.js';
 import userRoutes from './routes/user.routes.js';
 
+//  Utils
 import { logger } from './utils/logger.js';
 
 const app = express();
@@ -47,6 +53,23 @@ app.use('/api', subscribersRoutes);
 app.use('/api', tourRoutes);
 app.use('/api', countryRoutes);
 app.use('/api', parkRoutes);
+
+// openApi docs:
+const docsPath = path.join(process.cwd(), 'openapi');
+if (fs.existsSync(docsPath)) {
+  console.log('[INFO] Serving docs from:', docsPath);
+
+  app.use(
+    '/docs',
+    express.static(docsPath, {
+      index: 'index.html',
+    }),
+  );
+
+  console.log('[INFO]  Documentation available at: http://localhost:' + port + '/docs');
+} else {
+  console.log('[WARN]  OpenAPI directory not found at:', docsPath);
+}
 
 // 404 handler
 app.use((req, res) => {


### PR DESCRIPTION
# Add REDOC API Documentation

## What's New
- Interactive API docs at `/docs` endpoint
- Admin endpoints fully documented (create, get, delete, list users)
- Custom purple/cream theme
- Static file serving from OpenAPI spec

## How to Test
1. `npm run start`
2. Visit `http://localhost:3000/docs`
3. Explore the interactive documentation

## Notes
- First iteration with admin routes only
- Production-ready setup
- 130KB generated HTML documentation
- Would appreciate review on structure/styling
