### PR TITLE
chore(env): update backend API URL for production and handled edge case where user already exists on waitlist.

### DIFF
--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -1,7 +1,7 @@
 import type { SearchResponse, Tour } from '@/types/index';
 import axios from 'axios';
 
-const baseUrl = import.meta.env.VITE_BASE_URL || "http://localhost:3000";
+const baseUrl = import.meta.env.VITE_API_PATH || "http://localhost:3000";
 
 export async function getTours(): Promise<Tour[]> {
   const response = await axios.get<Tour[]>(`${baseUrl}/api/tours`);

--- a/frontend/src/components/layout/Mailbox/mailbox.component.tsx
+++ b/frontend/src/components/layout/Mailbox/mailbox.component.tsx
@@ -4,7 +4,7 @@ import { subscribeToWaitlist } from '@/api/api';
 
 const JoinWaitlistBox = () => {
   const [email, setEmail] = useState('');
-  const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error' | 'invalid'>('idle');
+  const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error' | 'invalid' | 'duplicate'>('idle');
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -19,10 +19,14 @@ const JoinWaitlistBox = () => {
       await subscribeToWaitlist(email);
       setStatus('success');
       setEmail('');
-    } catch {
-      setStatus('error');
+    } catch (error: any) {
+      if (error.response?.status === 409) {
+        setStatus('duplicate');
+      } else {
+        setStatus('error');
+      }
     }
-  };
+  }
 
   return (
     <div className='absolute left-1/2 bottom-24 sm:bottom-28 md:bottom-32 lg:bottom-40 -translate-x-1/2 z-50 w-full px-4'>
@@ -53,6 +57,11 @@ const JoinWaitlistBox = () => {
           </form>
           {status === 'invalid' && (
             <p className="text-red-700 mt-2 text-sm">Please enter a valid email address.</p>
+          )}
+          {status === 'duplicate' && (
+            <p className="text-red-500 mt-2 text-sm">
+              This email is already on the waitlist.
+            </p>
           )}
           {status === 'success' && (
             <p className="text-green-700 mt-2 text-sm">Thanks for joining the waitlist!</p>


### PR DESCRIPTION
**What Changed**
Changed environment variable from VITE_BASE_URL to VITE_API_PATH for clarity and consistency.

Tested with the local frontend connected to the deployed backend — verified that waitlist email creation works as expected.

**Edge Case Handling**
Added logic to handle the case where a user tries to join the waitlist with an email that already exists.

If the backend returns a 409 Conflict, the frontend now shows a friendly message: “This email is already on the waitlist.”

**Testing**
Verified that:

New emails can be successfully added to the waitlist.

Submitting an already-registered email shows the correct feedback.

No duplicate entries are created.