### PR TITLE
refactor(components): replace React namespace imports with named imports

### DIFF
--- a/frontend-platform/src/components/avatar/avatar.tsx
+++ b/frontend-platform/src/components/avatar/avatar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import * as React from 'react';
 import { cn } from '@/lib/utils';
+import { forwardRef, useEffect, useState } from 'react';
 
 export interface AvatarProps extends React.HTMLAttributes<HTMLDivElement> {
   className?: string;
@@ -18,30 +18,25 @@ export interface AvatarFallbackProps extends React.HTMLAttributes<HTMLDivElement
   children: React.ReactNode;
 }
 
-const Avatar = React.forwardRef<HTMLDivElement, AvatarProps>(
-  ({ className, children, ...props }, ref) => {
-    return (
-      <div
-        ref={ref}
-        className={cn(
-          'relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full',
-          className
-        )}
-        {...props}
-      >
-        {children}
-      </div>
-    );
-  }
-);
+const Avatar = forwardRef<HTMLDivElement, AvatarProps>(({ className, children, ...props }, ref) => {
+  return (
+    <div
+      ref={ref}
+      className={cn('relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full', className)}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+});
 Avatar.displayName = 'Avatar';
 
-const AvatarImage = React.forwardRef<HTMLImageElement, AvatarImageProps>(
+const AvatarImage = forwardRef<HTMLImageElement, AvatarImageProps>(
   ({ className, src, alt, onError, onLoad, ...props }, ref) => {
-    const [imageLoadError, setImageLoadError] = React.useState(false);
-    const [imageLoaded, setImageLoaded] = React.useState(false);
+    const [imageLoadError, setImageLoadError] = useState(false);
+    const [imageLoaded, setImageLoaded] = useState(false);
 
-    React.useEffect(() => {
+    useEffect(() => {
       setImageLoadError(false);
       setImageLoaded(false);
     }, [src]);
@@ -69,30 +64,30 @@ const AvatarImage = React.forwardRef<HTMLImageElement, AvatarImageProps>(
         onError={handleError}
         onLoad={handleLoad}
         style={{
-          display: imageLoaded ? 'block' : 'none'
+          display: imageLoaded ? 'block' : 'none',
         }}
         {...props}
       />
     );
-  }
+  },
 );
 AvatarImage.displayName = 'AvatarImage';
 
-const AvatarFallback = React.forwardRef<HTMLDivElement, AvatarFallbackProps>(
+const AvatarFallback = forwardRef<HTMLDivElement, AvatarFallbackProps>(
   ({ className, children, ...props }, ref) => {
     return (
       <div
         ref={ref}
         className={cn(
           'flex h-full w-full items-center justify-center rounded-full bg-muted text-muted-foreground font-medium',
-          className
+          className,
         )}
         {...props}
       >
         {children}
       </div>
     );
-  }
+  },
 );
 AvatarFallback.displayName = 'AvatarFallback';
 

--- a/frontend-platform/src/components/badge/badge.tsx
+++ b/frontend-platform/src/components/badge/badge.tsx
@@ -1,11 +1,11 @@
-import * as React from 'react';
 import { cn } from '@/lib/utils';
 
 const badgeVariants = {
   default: 'bg-primary text-primary-foreground hover:bg-primary/80',
   secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
   destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/80',
-  outline: 'text-foreground border border-input bg-background hover:bg-accent hover:text-accent-foreground',
+  outline:
+    'text-foreground border border-input bg-background hover:bg-accent hover:text-accent-foreground',
   warning: 'bg-warning text-warning-foreground hover:bg-warning/80',
   success: 'bg-success text-success-foreground hover:bg-success/80',
   info: 'bg-info text-info-foreground hover:bg-info/80',

--- a/frontend-platform/src/components/button/button.tsx
+++ b/frontend-platform/src/components/button/button.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import * as React from 'react';
 import { cn } from '@/lib/utils';
+import { cloneElement, forwardRef, isValidElement, ReactElement, useEffect } from 'react';
 
 // Button variants using object-based approach instead of class-variance-authority
 const buttonVariants = {
@@ -32,7 +32,7 @@ export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
   loading?: boolean;
 }
 
-const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   (
     {
       className,
@@ -47,7 +47,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     ref,
   ) => {
     // Enforce aria-label for icon-only buttons
-    React.useEffect(() => {
+    useEffect(() => {
       if (size === 'icon' && !props['aria-label'] && !props['aria-labelledby']) {
         console.warn(
           'Button with size="icon" should have an aria-label or aria-labelledby for accessibility. ' +
@@ -75,10 +75,10 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     );
 
     // Simplified asChild implementation
-    if (asChild && React.isValidElement(children) && !loading) {
-      const childElement = children as React.ReactElement<{ className?: string }>;
+    if (asChild && isValidElement(children) && !loading) {
+      const childElement = children as ReactElement<{ className?: string }>;
 
-      return React.cloneElement(childElement, {
+      return cloneElement(childElement, {
         ...childElement.props,
         className: cn(
           buttonBaseStyles,

--- a/frontend-platform/src/components/checkbox/checkbox.stories.tsx
+++ b/frontend-platform/src/components/checkbox/checkbox.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Checkbox } from './checkbox';
-import * as React from 'react';
 
 const meta: Meta<typeof Checkbox> = {
   title: 'Components/Checkbox',
@@ -55,7 +54,10 @@ export const WithLabel: Story = {
   render: (args: React.ComponentProps<typeof Checkbox>) => (
     <div className="flex items-center space-x-2">
       <Checkbox id="terms" {...args} />
-      <label htmlFor="terms" className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
+      <label
+        htmlFor="terms"
+        className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+      >
         Accept terms and conditions
       </label>
     </div>
@@ -67,19 +69,28 @@ export const FormExample: Story = {
     <div className="space-y-4">
       <div className="flex items-center space-x-2">
         <Checkbox id="newsletter" />
-        <label htmlFor="newsletter" className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
+        <label
+          htmlFor="newsletter"
+          className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+        >
           Subscribe to newsletter
         </label>
       </div>
       <div className="flex items-center space-x-2">
         <Checkbox id="marketing" />
-        <label htmlFor="marketing" className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
+        <label
+          htmlFor="marketing"
+          className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+        >
           Receive marketing emails
         </label>
       </div>
       <div className="flex items-center space-x-2">
         <Checkbox id="updates" defaultChecked />
-        <label htmlFor="updates" className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
+        <label
+          htmlFor="updates"
+          className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+        >
           Get product updates
         </label>
       </div>
@@ -94,19 +105,27 @@ export const CheckboxGroup: Story = {
       <div className="grid grid-cols-2 gap-3">
         <div className="flex items-center space-x-2">
           <Checkbox id="tech" />
-          <label htmlFor="tech" className="text-sm">Technology</label>
+          <label htmlFor="tech" className="text-sm">
+            Technology
+          </label>
         </div>
         <div className="flex items-center space-x-2">
           <Checkbox id="design" />
-          <label htmlFor="design" className="text-sm">Design</label>
+          <label htmlFor="design" className="text-sm">
+            Design
+          </label>
         </div>
         <div className="flex items-center space-x-2">
           <Checkbox id="business" />
-          <label htmlFor="business" className="text-sm">Business</label>
+          <label htmlFor="business" className="text-sm">
+            Business
+          </label>
         </div>
         <div className="flex items-center space-x-2">
           <Checkbox id="science" />
-          <label htmlFor="science" className="text-sm">Science</label>
+          <label htmlFor="science" className="text-sm">
+            Science
+          </label>
         </div>
       </div>
     </div>
@@ -118,19 +137,27 @@ export const AllStates: Story = {
     <div className="space-y-4">
       <div className="flex items-center space-x-2">
         <Checkbox id="unchecked" />
-        <label htmlFor="unchecked" className="text-sm">Unchecked</label>
+        <label htmlFor="unchecked" className="text-sm">
+          Unchecked
+        </label>
       </div>
       <div className="flex items-center space-x-2">
         <Checkbox id="checked" checked />
-        <label htmlFor="checked" className="text-sm">Checked</label>
+        <label htmlFor="checked" className="text-sm">
+          Checked
+        </label>
       </div>
       <div className="flex items-center space-x-2">
         <Checkbox id="disabled-unchecked" disabled />
-        <label htmlFor="disabled-unchecked" className="text-sm">Disabled Unchecked</label>
+        <label htmlFor="disabled-unchecked" className="text-sm">
+          Disabled Unchecked
+        </label>
       </div>
       <div className="flex items-center space-x-2">
         <Checkbox id="disabled-checked" disabled checked />
-        <label htmlFor="disabled-checked" className="text-sm">Disabled Checked</label>
+        <label htmlFor="disabled-checked" className="text-sm">
+          Disabled Checked
+        </label>
       </div>
     </div>
   ),

--- a/frontend-platform/src/components/collapsible/collapsible.stories.tsx
+++ b/frontend-platform/src/components/collapsible/collapsible.stories.tsx
@@ -3,8 +3,8 @@ import { Collapsible, CollapsibleTrigger, CollapsibleContent } from './collapsib
 import { Button } from '../button/button';
 import { Card } from '../card/card';
 import { Badge } from '../badge/badge';
-import * as React from 'react';
 import { ChevronDown, ChevronRight, Settings, User, Bell } from 'lucide-react';
+import { useState } from 'react';
 
 const meta: Meta<typeof Collapsible> = {
   title: 'Components/Collapsible',
@@ -72,15 +72,21 @@ export const WithCard: Story = {
             <div className="px-4 pb-4 space-y-3">
               <div className="flex items-center justify-between">
                 <span className="text-sm">Notifications</span>
-                <Button size="sm" variant="outline">Configure</Button>
+                <Button size="sm" variant="outline">
+                  Configure
+                </Button>
               </div>
               <div className="flex items-center justify-between">
                 <span className="text-sm">Privacy</span>
-                <Button size="sm" variant="outline">Manage</Button>
+                <Button size="sm" variant="outline">
+                  Manage
+                </Button>
               </div>
               <div className="flex items-center justify-between">
                 <span className="text-sm">Account</span>
-                <Button size="sm" variant="outline">Edit</Button>
+                <Button size="sm" variant="outline">
+                  Edit
+                </Button>
               </div>
             </div>
           </CollapsibleContent>
@@ -92,22 +98,17 @@ export const WithCard: Story = {
 
 export const ControlledExample: Story = {
   render: () => {
-    const [isOpen, setIsOpen] = React.useState(false);
-    
+    const [isOpen, setIsOpen] = useState(false);
+
     return (
       <div className="w-80 space-y-4">
         <div className="flex items-center gap-2">
-          <Button 
-            size="sm" 
-            onClick={() => setIsOpen(!isOpen)}
-          >
+          <Button size="sm" onClick={() => setIsOpen(!isOpen)}>
             {isOpen ? 'Close' : 'Open'} Externally
           </Button>
-          <Badge variant={isOpen ? 'success' : 'secondary'}>
-            {isOpen ? 'Open' : 'Closed'}
-          </Badge>
+          <Badge variant={isOpen ? 'success' : 'secondary'}>{isOpen ? 'Open' : 'Closed'}</Badge>
         </div>
-        
+
         <Collapsible open={isOpen} onOpenChange={setIsOpen}>
           <CollapsibleTrigger asChild>
             <Button variant="outline" className="w-full justify-between">
@@ -117,8 +118,8 @@ export const ControlledExample: Story = {
           </CollapsibleTrigger>
           <CollapsibleContent className="mt-2 p-4 border rounded-md">
             <p className="text-sm">
-              This collapsible is controlled by external state. 
-              Current state: <strong>{isOpen ? 'Open' : 'Closed'}</strong>
+              This collapsible is controlled by external state. Current state:{' '}
+              <strong>{isOpen ? 'Open' : 'Closed'}</strong>
             </p>
           </CollapsibleContent>
         </Collapsible>
@@ -129,49 +130,41 @@ export const ControlledExample: Story = {
 
 export const MultipleCollapsibles: Story = {
   render: () => {
-    const [openItems, setOpenItems] = React.useState<string[]>([]);
-    
+    const [openItems, setOpenItems] = useState<string[]>([]);
+
     const toggleItem = (item: string) => {
-      setOpenItems(prev => 
-        prev.includes(item) 
-          ? prev.filter(i => i !== item)
-          : [...prev, item]
+      setOpenItems((prev) =>
+        prev.includes(item) ? prev.filter((i) => i !== item) : [...prev, item],
       );
     };
-    
+
     const sections = [
       { id: 'profile', title: 'Profile Settings', icon: User },
       { id: 'notifications', title: 'Notifications', icon: Bell },
       { id: 'advanced', title: 'Advanced Options', icon: Settings },
     ];
-    
+
     return (
       <div className="w-96 space-y-2">
         {sections.map(({ id, title, icon: Icon }) => (
-          <Collapsible 
-            key={id}
-            open={openItems.includes(id)}
-            onOpenChange={() => toggleItem(id)}
-          >
+          <Collapsible key={id} open={openItems.includes(id)} onOpenChange={() => toggleItem(id)}>
             <CollapsibleTrigger asChild>
-              <Button 
-                variant="outline" 
-                className="w-full justify-between"
-              >
+              <Button variant="outline" className="w-full justify-between">
                 <div className="flex items-center gap-2">
                   <Icon className="h-4 w-4" />
                   {title}
                 </div>
-                {openItems.includes(id) ? 
-                  <ChevronDown className="h-4 w-4" /> : 
+                {openItems.includes(id) ? (
+                  <ChevronDown className="h-4 w-4" />
+                ) : (
                   <ChevronRight className="h-4 w-4" />
-                }
+                )}
               </Button>
             </CollapsibleTrigger>
             <CollapsibleContent className="mt-1 p-3 border rounded-md bg-gray-50">
               <p className="text-sm text-gray-600">
-                Content for {title.toLowerCase()}. This section contains 
-                various options and settings related to {title.toLowerCase()}.
+                Content for {title.toLowerCase()}. This section contains various options and
+                settings related to {title.toLowerCase()}.
               </p>
             </CollapsibleContent>
           </Collapsible>
@@ -193,7 +186,7 @@ export const NestedCollapsibles: Story = {
         </CollapsibleTrigger>
         <CollapsibleContent className="mt-2 p-4 border rounded-md space-y-2">
           <p className="text-sm mb-3">This is the main category content.</p>
-          
+
           <Collapsible>
             <CollapsibleTrigger asChild>
               <Button variant="ghost" size="sm" className="w-full justify-between">
@@ -202,12 +195,10 @@ export const NestedCollapsibles: Story = {
               </Button>
             </CollapsibleTrigger>
             <CollapsibleContent className="mt-1 p-2 bg-gray-100 rounded">
-              <p className="text-xs text-gray-600">
-                Nested content for subcategory 1.
-              </p>
+              <p className="text-xs text-gray-600">Nested content for subcategory 1.</p>
             </CollapsibleContent>
           </Collapsible>
-          
+
           <Collapsible>
             <CollapsibleTrigger asChild>
               <Button variant="ghost" size="sm" className="w-full justify-between">
@@ -216,9 +207,7 @@ export const NestedCollapsibles: Story = {
               </Button>
             </CollapsibleTrigger>
             <CollapsibleContent className="mt-1 p-2 bg-gray-100 rounded">
-              <p className="text-xs text-gray-600">
-                Nested content for subcategory 2.
-              </p>
+              <p className="text-xs text-gray-600">Nested content for subcategory 2.</p>
             </CollapsibleContent>
           </Collapsible>
         </CollapsibleContent>
@@ -243,7 +232,7 @@ export const DisabledState: Story = {
           </p>
         </CollapsibleContent>
       </Collapsible>
-      
+
       <Collapsible>
         <CollapsibleTrigger asChild>
           <Button variant="outline" className="w-full justify-between">
@@ -274,8 +263,8 @@ export const AnimatedExample: Story = {
         <CollapsibleContent className="mt-2 overflow-hidden transition-all duration-300 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0">
           <div className="p-4 border rounded-md">
             <p className="text-sm text-gray-600">
-              This collapsible has smooth animations when opening and closing.
-              The chevron icon also rotates to indicate the state.
+              This collapsible has smooth animations when opening and closing. The chevron icon also
+              rotates to indicate the state.
             </p>
           </div>
         </CollapsibleContent>

--- a/frontend-platform/src/components/command/command.stories.tsx
+++ b/frontend-platform/src/components/command/command.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
-import * as React from 'react';
 import {
   Command,
   CommandDialog,
@@ -26,6 +25,8 @@ import {
   PlusCircle,
 } from 'lucide-react';
 import { Button } from '../button/button';
+import { useEffect } from 'react';
+import { useState } from 'react';
 
 const meta: Meta<typeof Command> = {
   title: 'Components/Command',
@@ -87,9 +88,9 @@ export const Default: Story = {
 
 export const WithDialog: Story = {
   render: () => {
-    const [open, setOpen] = React.useState(false);
+    const [open, setOpen] = useState(false);
 
-    React.useEffect(() => {
+    useEffect(() => {
       const down = (e: KeyboardEvent) => {
         if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
           e.preventDefault();
@@ -177,7 +178,7 @@ export const WithDialog: Story = {
 
 export const SearchExample: Story = {
   render: () => {
-    const [value, setValue] = React.useState('');
+    const [value, setValue] = useState('');
 
     const frameworks = [
       { value: 'next.js', label: 'Next.js', icon: '⚡' },

--- a/frontend-platform/src/components/dialog/dialog.stories.tsx
+++ b/frontend-platform/src/components/dialog/dialog.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
-import * as React from 'react';
 import {
   Dialog,
   DialogContent,
@@ -10,6 +9,7 @@ import {
   DialogTrigger,
 } from './dialog';
 import { Button } from '../button/button';
+import { useState } from 'react';
 
 type DialogProps = React.ComponentProps<typeof Dialog>;
 
@@ -62,7 +62,8 @@ export const Default: Story = {
         </DialogHeader>
         <div className="py-4">
           <p className="text-sm text-muted-foreground">
-            This is the main content area of the dialog. You can place forms, text, or any other components here.
+            This is the main content area of the dialog. You can place forms, text, or any other
+            components here.
           </p>
         </div>
         <DialogFooter>
@@ -85,7 +86,8 @@ export const Confirmation: Story = {
         <DialogHeader>
           <DialogTitle>Are you absolutely sure?</DialogTitle>
           <DialogDescription>
-            This action cannot be undone. This will permanently delete your account and remove your data from our servers.
+            This action cannot be undone. This will permanently delete your account and remove your
+            data from our servers.
           </DialogDescription>
         </DialogHeader>
         <DialogFooter>
@@ -144,8 +146,8 @@ export const FormDialog: Story = {
 // Controlled Dialog
 export const Controlled: Story = {
   render: () => {
-    const [open, setOpen] = React.useState(false);
-    
+    const [open, setOpen] = useState(false);
+
     return (
       <div className="space-y-4">
         <div className="flex items-center space-x-2">
@@ -154,7 +156,7 @@ export const Controlled: Story = {
             Dialog is {open ? 'open' : 'closed'}
           </span>
         </div>
-        
+
         <Dialog open={open} onOpenChange={setOpen}>
           <DialogContent>
             <DialogHeader>
@@ -165,7 +167,8 @@ export const Controlled: Story = {
             </DialogHeader>
             <div className="py-4">
               <p className="text-sm">
-                You can control this dialog programmatically using the open prop and onOpenChange callback.
+                You can control this dialog programmatically using the open prop and onOpenChange
+                callback.
               </p>
             </div>
             <DialogFooter>
@@ -191,33 +194,41 @@ export const LargeContent: Story = {
       <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Terms and Conditions</DialogTitle>
-          <DialogDescription>
-            Please read our terms and conditions carefully.
-          </DialogDescription>
+          <DialogDescription>Please read our terms and conditions carefully.</DialogDescription>
         </DialogHeader>
         <div className="py-4 space-y-4">
           <div>
             <h3 className="font-semibold mb-2">1. Acceptance of Terms</h3>
             <p className="text-sm text-muted-foreground">
-              By accessing and using this service, you accept and agree to be bound by the terms and provision of this agreement.
+              By accessing and using this service, you accept and agree to be bound by the terms and
+              provision of this agreement.
             </p>
           </div>
           <div>
             <h3 className="font-semibold mb-2">2. Use License</h3>
             <p className="text-sm text-muted-foreground">
-              Permission is granted to temporarily download one copy of the materials on our website for personal, non-commercial transitory viewing only.
+              Permission is granted to temporarily download one copy of the materials on our website
+              for personal, non-commercial transitory viewing only.
             </p>
           </div>
           <div>
             <h3 className="font-semibold mb-2">3. Disclaimer</h3>
             <p className="text-sm text-muted-foreground">
-              The materials on our website are provided on an 'as is' basis. We make no warranties, expressed or implied, and hereby disclaim and negate all other warranties including without limitation, implied warranties or conditions of merchantability, fitness for a particular purpose, or non-infringement of intellectual property or other violation of rights.
+              The materials on our website are provided on an 'as is' basis. We make no warranties,
+              expressed or implied, and hereby disclaim and negate all other warranties including
+              without limitation, implied warranties or conditions of merchantability, fitness for a
+              particular purpose, or non-infringement of intellectual property or other violation of
+              rights.
             </p>
           </div>
           <div>
             <h3 className="font-semibold mb-2">4. Limitations</h3>
             <p className="text-sm text-muted-foreground">
-              In no event shall our company or its suppliers be liable for any damages (including, without limitation, damages for loss of data or profit, or due to business interruption) arising out of the use or inability to use the materials on our website, even if we or our authorized representative has been notified orally or in writing of the possibility of such damage.
+              In no event shall our company or its suppliers be liable for any damages (including,
+              without limitation, damages for loss of data or profit, or due to business
+              interruption) arising out of the use or inability to use the materials on our website,
+              even if we or our authorized representative has been notified orally or in writing of
+              the possibility of such damage.
             </p>
           </div>
         </div>
@@ -254,12 +265,13 @@ export const CustomStyled: Story = {
           </div>
         </div>
         <DialogFooter>
-          <Button variant="outline" className="border-purple-300 text-purple-700 hover:bg-purple-50">
+          <Button
+            variant="outline"
+            className="border-purple-300 text-purple-700 hover:bg-purple-50"
+          >
             Cancel
           </Button>
-          <Button className="bg-purple-600 hover:bg-purple-700">
-            Continue
-          </Button>
+          <Button className="bg-purple-600 hover:bg-purple-700">Continue</Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/frontend-platform/src/components/dropdown-menu/dropdown-menu.stories.tsx
+++ b/frontend-platform/src/components/dropdown-menu/dropdown-menu.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
-import * as React from 'react';
+
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -31,6 +31,7 @@ import {
   Keyboard,
   CreditCard,
 } from 'lucide-react';
+import { useState } from 'react';
 
 type DropdownMenuProps = React.ComponentProps<typeof DropdownMenu>;
 
@@ -202,9 +203,9 @@ export const WithSubmenus: Story = {
 // With Checkboxes
 export const WithCheckboxes: Story = {
   render: () => {
-    const [showStatusBar, setShowStatusBar] = React.useState(true);
-    const [showActivityBar, setShowActivityBar] = React.useState(false);
-    const [showPanel, setShowPanel] = React.useState(false);
+    const [showStatusBar, setShowStatusBar] = useState(true);
+    const [showActivityBar, setShowActivityBar] = useState(false);
+    const [showPanel, setShowPanel] = useState(false);
 
     return (
       <DropdownMenu>
@@ -236,7 +237,7 @@ export const WithCheckboxes: Story = {
 // With Radio Groups
 export const WithRadioGroups: Story = {
   render: () => {
-    const [position, setPosition] = React.useState('bottom');
+    const [position, setPosition] = useState('bottom');
 
     return (
       <DropdownMenu>
@@ -260,7 +261,7 @@ export const WithRadioGroups: Story = {
 // Controlled Example
 export const Controlled: Story = {
   render: () => {
-    const [open, setOpen] = React.useState(false);
+    const [open, setOpen] = useState(false);
 
     return (
       <div className="space-y-4">
@@ -299,9 +300,9 @@ export const Controlled: Story = {
 // Complex Example with Groups
 export const ComplexExample: Story = {
   render: () => {
-    const [bookmarksChecked, setBookmarksChecked] = React.useState(true);
-    const [urlsChecked, setUrlsChecked] = React.useState(false);
-    const [person, setPerson] = React.useState('pedro');
+    const [bookmarksChecked, setBookmarksChecked] = useState(true);
+    const [urlsChecked, setUrlsChecked] = useState(false);
+    const [person, setPerson] = useState('pedro');
 
     return (
       <DropdownMenu>

--- a/frontend-platform/src/components/navigation-menu/navigation-menu.stories.tsx
+++ b/frontend-platform/src/components/navigation-menu/navigation-menu.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
-import * as React from 'react';
+
 import {
   NavigationMenu,
   NavigationMenuContent,
@@ -21,6 +21,7 @@ import {
   MapPin,
   ExternalLink,
 } from 'lucide-react';
+import { forwardRef } from 'react';
 
 type NavigationMenuProps = React.ComponentProps<typeof NavigationMenu>;
 
@@ -55,30 +56,27 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 // Helper component for consistent link styling
-const ListItem = React.forwardRef<
-  React.ComponentRef<'a'>,
-  React.ComponentPropsWithoutRef<'a'>
->(({ className, title, children, ...props }, ref) => {
-  return (
-    <li>
-      <NavigationMenuLink asChild>
-        <a
-          ref={ref}
-          className={cn(
-            'block select-none space-y-1 rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground',
-            className
-          )}
-          {...props}
-        >
-          <div className="text-sm font-medium leading-none">{title}</div>
-          <p className="line-clamp-2 text-sm leading-snug text-muted-foreground">
-            {children}
-          </p>
-        </a>
-      </NavigationMenuLink>
-    </li>
-  );
-});
+const ListItem = forwardRef<React.ComponentRef<'a'>, React.ComponentPropsWithoutRef<'a'>>(
+  ({ className, title, children, ...props }: React.ComponentPropsWithoutRef<'a'>, ref) => {
+    return (
+      <li>
+        <NavigationMenuLink asChild>
+          <a
+            ref={ref}
+            className={cn(
+              'block select-none space-y-1 rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground',
+              className,
+            )}
+            {...props}
+          >
+            <div className="text-sm font-medium leading-none">{title}</div>
+            <p className="line-clamp-2 text-sm leading-snug text-muted-foreground">{children}</p>
+          </a>
+        </NavigationMenuLink>
+      </li>
+    );
+  },
+);
 ListItem.displayName = 'ListItem';
 
 export const Default: Story = {
@@ -95,12 +93,9 @@ export const Default: Story = {
                     className="flex h-full w-full select-none flex-col justify-end rounded-md bg-gradient-to-b from-muted/50 to-muted p-6 no-underline outline-none focus:shadow-md"
                     href="/"
                   >
-                    <div className="mb-2 mt-4 text-lg font-medium">
-                      shadcn/ui
-                    </div>
+                    <div className="mb-2 mt-4 text-lg font-medium">shadcn/ui</div>
                     <p className="text-sm leading-tight text-muted-foreground">
-                      Beautifully designed components built with Radix UI and
-                      Tailwind CSS.
+                      Beautifully designed components built with Radix UI and Tailwind CSS.
                     </p>
                   </a>
                 </NavigationMenuLink>


### PR DESCRIPTION
This commit updates multiple component files to use named imports from 'react' instead of the React namespace import pattern. The changes improve code readability and maintain consistency with modern React best practices. All component functionality remains unchanged.